### PR TITLE
Add Build123d LLM Workbench design document and curriculum

### DIFF
--- a/docs/build123d-llm-workbench.md
+++ b/docs/build123d-llm-workbench.md
@@ -1,6 +1,6 @@
 # Build123d LLM Workbench — Design Document
 
-> **Status:** Draft v0.2 — 2026-02-24
+> **Status:** Draft v0.3 — 2026-02-24
 > **Owner:** kreuzhofer
 > **Branch:** `claude/build123d-llm-workbench-Zzddt`
 
@@ -694,7 +694,109 @@ All guarded by `AdminRouteGuard`. Navigation entry added to admin nav group.
 
 ---
 
-## 15. Open Questions / Deferred Decisions
+## 15. Parts Knowledge Library (Future)
+
+### 15.1 Problem
+
+Higher-complexity categories (8–11) reference real-world hardware: Raspberry Pi 4, Arduino Uno, ESP32 DevKit, etc. The code-generation LLM needs precise dimensional knowledge to produce correct port cutout positions, standoff hole patterns, and PCB footprints. This knowledge should **not** be required in the user prompt — a user should be able to type *"A case for a Raspberry Pi 4"* without specifying that the USB-A ports are 17.4mm × 15.0mm at a 29mm offset from the board edge.
+
+### 15.2 Approach
+
+An expandable library of **part datasheets** stored as structured Markdown or YAML files, version-controlled in the repository and seeded into a `workbench_part_datasheets` table.
+
+```
+workbench/
+  parts/
+    raspberry-pi-4-model-b.md
+    raspberry-pi-5.md
+    raspberry-pi-zero-2-w.md
+    arduino-uno-r3.md
+    arduino-mega-2560.md
+    arduino-nano.md
+    esp32-devkit-v1.md
+    esp32-cam.md
+    nodemcu-esp8266-v3.md
+    jetson-nano-b01.md
+    ...
+```
+
+Each file contains:
+- **PCB dimensions** (length × width × thickness in mm)
+- **Mounting holes** (positions relative to a corner origin, hole diameter, recommended standoff height)
+- **Port inventory** (type, position, cutout dimensions: width × height × offset from board edge)
+- **Connectors** (GPIO header position, ribbon cable slots, antenna connectors)
+- **Thermal zones** (SoC position for heatsink/vent placement)
+- **Keep-out zones** (areas that need clearance, e.g., SD card slot ejection path)
+
+### 15.3 Context Injection
+
+When a prompt mentions a known part (e.g., "Raspberry Pi 4"), the system automatically:
+1. Detects the part reference via keyword matching or entity extraction.
+2. Retrieves the matching datasheet from the library.
+3. Appends it to the code-generation prompt as a structured reference section **after** the system prompt and **before** the user prompt.
+
+This is analogous to RAG but with curated, hand-verified data instead of vector-search results. The datasheets are small enough (typically < 2K tokens each) to include in full without chunking.
+
+### 15.4 Scope
+
+This is **future work** — not in the current implementation phases. The initial training run will rely on the LLM's existing knowledge of popular board dimensions (which is reasonably good for Raspberry Pi / Arduino but poor for niche boards). The parts library becomes critical when:
+- Expanding to niche boards (STM32 Nucleo variants, custom PCBs)
+- Requiring sub-millimeter accuracy on port cutout placement
+- Training for production-quality enclosure design
+
+### 15.5 Database Extension (Future)
+
+```sql
+CREATE TABLE workbench_part_datasheets (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug        VARCHAR(255) NOT NULL UNIQUE,  -- e.g., "raspberry-pi-4-model-b"
+  name        VARCHAR(255) NOT NULL,
+  keywords    TEXT[] NOT NULL,               -- matching triggers: ["raspberry pi 4", "rpi4", "pi 4 model b"]
+  content     TEXT NOT NULL,                 -- full datasheet markdown
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+---
+
+## 16. 3D Printing Design Guidelines (Future)
+
+### 16.1 Problem
+
+Fine-tuning for correct Build123d code is necessary but not sufficient. For practical use, generated enclosures and parts must be **3D-printable** without excessive supports, warping, or failed prints. This is a separate concern from geometric correctness.
+
+### 16.2 Approach
+
+An optional **3D-printability guidelines** document stored as `workbench/3d-printing-guidelines.md`. When activated, this is appended to the system prompt to bias the LLM toward print-friendly designs.
+
+Topics to cover:
+- **Overhangs**: Maximum unsupported overhang angle (typically 45°); when to add chamfers or support ribs
+- **Bridges**: Maximum bridging span (typically 50mm); how to break long bridges with intermediate supports
+- **Minimum wall thickness**: Typically 1.2mm (3 perimeters at 0.4mm nozzle)
+- **Minimum hole diameter**: Typically 2mm; compensation for shrinkage on small holes
+- **Threads**: Avoid printed threads < M6; prefer heat-set inserts for M2–M4; thread pitch and clearance
+- **Snap fits**: Recommended deflection, wall thickness, and draft angles for FDM snap clips
+- **Orientation awareness**: Design features with a flat bottom for bed adhesion; minimize the number of support-requiring overhangs
+- **Tolerances**: Typical FDM tolerance ±0.2mm; clearance fits for mating parts (0.3–0.5mm gap)
+- **Elephant's foot**: First-layer compensation; chamfer bottom edges 0.4mm
+- **Split bodies**: When to split a part into multiple pieces for easier printing
+- **Screw bosses**: Wall thickness around heat-set inserts, recommended hole dimensions
+
+### 16.3 Context Injection
+
+This guideline document is **optional** and controlled via a toggle:
+- Stored as a versioned entry in `workbench_system_prompts` (separate from the main Build123d API reference)
+- An `include_print_guidelines` boolean flag on batch generation jobs controls whether it's appended
+- Useful for A/B testing: generate the same prompt with and without print guidelines to measure impact
+
+### 16.4 Scope
+
+This is **future work** — not in the current implementation phases. The initial training run focuses on geometric correctness. Print-friendliness is a quality-of-life improvement that can be layered on in a subsequent training iteration, potentially as a separate LoRA adapter or merged fine-tune.
+
+---
+
+## 17. Open Questions / Deferred Decisions
 
 | # | Question | Status |
 |---|----------|--------|
@@ -704,7 +806,10 @@ All guarded by `AdminRouteGuard`. Navigation entry added to admin nav group.
 | 4 | Rate limiting on `/generate` batch endpoint? | Add in Phase 3 |
 | 5 | File storage path for workbench renders | `/data/storage/workbench/{exampleId}/` |
 | 6 | Batch job persistence (in-memory vs DB-backed queue)? | Start in-memory; upgrade if needed |
+| 7 | Parts knowledge library: initial board set and datasheet format? | Future — see §15 |
+| 8 | 3D-printability guidelines: include in v1 training or separate LoRA? | Future — see §16 |
+| 9 | Parts library: keyword matching vs embedding-based retrieval? | Future — start with keywords |
 
 ---
 
-*End of Design Document v0.2*
+*End of Design Document v0.3*

--- a/docs/build123d-llm-workbench.md
+++ b/docs/build123d-llm-workbench.md
@@ -1,0 +1,670 @@
+# Build123d LLM Workbench — Design Document
+
+> **Status:** Draft v0.1 — 2026-02-24
+> **Owner:** kreuzhofer
+> **Branch:** `claude/build123d-llm-workbench-Zzddt`
+
+---
+
+## 1. Overview & Goals
+
+The Build123d LLM Workbench is an admin-only feature within the Chat3D application. Its purpose is to generate, validate, and curate a high-quality dataset of Build123d Python code examples, which will be used to fine-tune an open-weight LLM specifically for 3D CAD code generation.
+
+### Problem
+
+No currently available LLM generates reliable Build123d code out of the box. Build123d is a relatively niche Python CAD library, and models hallucinate incorrect class names, wrong argument order, and invalid geometry operations. A fine-tuned model with a well-curated dataset would dramatically improve code generation quality inside Chat3D.
+
+### Solution
+
+A progressively structured dataset generation pipeline:
+
+1. A **complexity curriculum** of 50 categories, ordered from simple primitives to complex assemblies.
+2. An **iterative code generation and validation loop** per category: generate → render → screenshot → human review → approve or fix.
+3. Validated examples from simpler categories **feed as few-shot context** into generation prompts for harder categories.
+4. Approved examples accumulate into an **exportable training dataset** for LLM fine-tuning.
+
+### Scope
+
+- Admin-only feature, accessible at `/workbench` in the frontend.
+- Backend API under `/api/admin/workbench/`.
+- New standalone Docker service: `screenshot-service` (Puppeteer + Three.js STL renderer).
+- New database tables in the existing PostgreSQL instance.
+- No changes to the user-facing Chat3D experience.
+
+---
+
+## 2. Key Design Decisions
+
+### 2.1 Integrated into Chat3D, Not a Separate App
+
+The workbench reuses the existing auth system (admin role check), LLM infrastructure (Vercel AI SDK + provider configuration), Build123d render service, and database. A separate app would duplicate all of this for no benefit at this stage.
+
+### 2.2 Screenshot Service as a Separate Docker Container
+
+The Puppeteer + Three.js STL-to-PNG renderer requires Chromium, which is a heavyweight dependency inappropriate to include in the main backend image. It is extracted as a standalone service:
+
+- Keeps backend image lean.
+- Can be scaled or replaced independently (e.g., replace with a GPU renderer later).
+- Based on the implementation in the previous `chat3d-docker` project (`imageRenderer.ts`).
+- New environment variable: `SCREENSHOT_SERVICE_URL`.
+
+### 2.3 Full Example Retrieval (No Chunking)
+
+When selecting prior examples for few-shot context, we always retrieve **complete code examples**, never partial chunks. Chunking risks cutting off import statements, context managers, or the export call — making examples useless or misleading. We limit the number of examples injected rather than their size.
+
+### 2.4 Human-in-the-Loop for Visual Validation
+
+The render service tells us if code is syntactically correct and produces a valid geometry file. It does **not** tell us if the object looks right. A cube with wrong proportions still renders successfully. Therefore:
+
+- Automated validation = no render error + no Python exception.
+- Visual validation = human reviews the screenshot and approves or rejects.
+- The LLM fix loop handles render errors automatically (up to `MAX_AUTO_FIX_ITERATIONS = 5`).
+- After that, human intervention is required.
+
+### 2.5 System Prompt as a Versioned File Asset
+
+The Build123d comprehensive system prompt is stored as a file asset in the backend (`src/data/build123d-system-prompt.md`), not in the database. This keeps it version-controlled, easily editable, and trivial to include in training data. A future extension could store multiple versions in the DB for A/B testing prompt strategies.
+
+### 2.6 Target Fine-Tuning Model: Qwen3-Coder-Next
+
+**Selected:** `Qwen3-Coder-Next` (released February 2026, Alibaba Qwen team)
+
+| Property | Value |
+|----------|-------|
+| Architecture | MoE, 80B total params, **3B active per token** |
+| Context window | 256K tokens |
+| 4-bit GGUF size | ~46 GB (fits single DGX Spark, 128 GB) |
+| BF16 LoRA training | Fits single DGX Spark with Unsloth |
+| SWE-Bench Verified | 70.6 (state of the art at its class) |
+| Inference throughput | ~10× vs dense equivalent |
+| License | Apache 2.0 |
+| Fine-tuning framework | Unsloth (MoE training 12× faster, 35% less VRAM) |
+
+**Why not MiniMax-Text-01:** 456B total params, does not fit 128 GB DGX Spark even quantized, proprietary license, no public fine-tuning toolchain.
+
+**Runner-up:** `Qwen2.5-Coder-32B` (64 GB BF16, Apache 2.0, very mature fine-tuning toolchain via LLaMA-Factory / Axolotl / Unsloth). Use if Qwen3-Coder-Next tooling proves immature.
+
+### 2.7 Training Dataset Output Format
+
+Deferred — will target LLaMA-Factory JSONL (conversation format with `system`/`user`/`assistant` roles) as the default, which is compatible with the broadest range of training frameworks. Final format decision comes when we begin training runs.
+
+---
+
+## 3. Architecture Overview
+
+```mermaid
+graph TD
+    Admin["Admin Browser\n/workbench"] -->|JWT, admin role| Backend["Backend\n:3001 /api/admin/workbench"]
+    Backend -->|POST /render/| Build123d["Build123d Service\n:30222"]
+    Backend -->|POST /screenshot| Screenshot["Screenshot Service\n:3002"]
+    Backend -->|generateText| LLM["LLM Provider\n(Anthropic/OpenAI/Ollama)"]
+    Backend <-->|SQL| DB["PostgreSQL\n:5432"]
+    Build123d -->|.step/.stl| Storage["/data/storage"]
+    Screenshot -->|PNG| Backend
+    Backend -->|GET /api/files/| Admin
+```
+
+### New Docker Services
+
+| Service | Image | Port | Purpose |
+|---------|-------|------|---------|
+| `screenshot-service` | Custom (Node 20 + Chromium) | 3002 | STL → PNG via Puppeteer + Three.js |
+
+### New Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `SCREENSHOT_SERVICE_URL` | `http://screenshot-service:3002` | URL of screenshot service |
+
+---
+
+## 4. Database Schema
+
+Three new tables, all scoped to admin use (no `owner_id` — they are global admin resources).
+
+### 4.1 `workbench_categories`
+
+```sql
+CREATE TABLE workbench_categories (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  rank        INTEGER NOT NULL UNIQUE,           -- 1–50, sort order
+  tier        INTEGER NOT NULL,                  -- 0–5, complexity tier
+  name        VARCHAR(255) NOT NULL,
+  description TEXT NOT NULL,                     -- human-readable goal description
+  hint        TEXT,                              -- optional: suggested approach / key APIs to use
+  status      VARCHAR(30) NOT NULL DEFAULT 'pending'
+              CHECK (status IN ('pending', 'in_progress', 'has_draft', 'approved', 'skipped')),
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+**Statuses:**
+- `pending` — not started
+- `in_progress` — generation/validation is actively being worked on
+- `has_draft` — at least one example has been generated but none approved yet
+- `approved` — at least one example approved; category is usable as few-shot context
+- `skipped` — consciously excluded from the dataset
+
+### 4.2 `workbench_examples`
+
+```sql
+CREATE TABLE workbench_examples (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  category_id     UUID NOT NULL REFERENCES workbench_categories(id) ON DELETE CASCADE,
+  iteration       INTEGER NOT NULL DEFAULT 1,    -- auto-increments per category
+  code            TEXT NOT NULL,                 -- executable Build123d Python
+  render_status   VARCHAR(20) NOT NULL DEFAULT 'pending'
+                  CHECK (render_status IN ('pending', 'rendering', 'success', 'error')),
+  render_error    TEXT,                          -- error message if render failed
+  stl_path        TEXT,                          -- path to generated .stl file (for screenshot)
+  step_path       TEXT,                          -- path to generated .step file
+  screenshot_front    TEXT,                      -- base64 PNG, front angle
+  screenshot_top      TEXT,                      -- base64 PNG, top angle
+  screenshot_iso      TEXT,                      -- base64 PNG, isometric angle
+  approval_status VARCHAR(20) NOT NULL DEFAULT 'pending'
+                  CHECK (approval_status IN ('pending', 'approved', 'rejected')),
+  rejection_note  TEXT,                          -- human note if rejected
+  llm_model       VARCHAR(255),                  -- which model generated this
+  prompt_tokens   INTEGER,
+  completion_tokens INTEGER,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_wb_examples_category ON workbench_examples(category_id);
+CREATE INDEX idx_wb_examples_approval ON workbench_examples(approval_status);
+```
+
+### 4.3 `workbench_system_prompts`
+
+```sql
+CREATE TABLE workbench_system_prompts (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  version     INTEGER NOT NULL UNIQUE,
+  label       VARCHAR(255) NOT NULL,
+  content     TEXT NOT NULL,                     -- full system prompt text
+  is_active   BOOLEAN NOT NULL DEFAULT FALSE,    -- only one active at a time
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+Seeded with `version=1` from `src/data/build123d-system-prompt.md` on first run. Later versions can be added via the UI for prompt A/B testing.
+
+---
+
+## 5. API Contract
+
+All routes under `/api/admin/workbench` require `requireAuth` + `requireRole("admin")` middleware.
+
+### 5.1 Categories
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/categories` | List all categories (sorted by rank) |
+| `GET` | `/categories/:id` | Get category + its examples |
+| `POST` | `/categories` | Create a category (manual or bulk seed) |
+| `PATCH` | `/categories/:id` | Update status, hint, name, description |
+| `POST` | `/categories/seed` | Seed the default 50-category curriculum |
+
+### 5.2 Examples
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/examples/:id` | Get a single example (with screenshots) |
+| `POST` | `/examples/generate` | Generate a new example for a category (LLM + render + screenshot) |
+| `POST` | `/examples/:id/render` | Re-render an existing example's code |
+| `POST` | `/examples/:id/screenshot` | Re-screenshot an already-rendered example |
+| `PATCH` | `/examples/:id/approve` | Approve an example |
+| `PATCH` | `/examples/:id/reject` | Reject an example with optional note |
+| `PATCH` | `/examples/:id/code` | Update code manually (for human fixes) |
+
+### 5.3 System Prompts
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/system-prompts` | List all system prompt versions |
+| `GET` | `/system-prompts/active` | Get the currently active system prompt |
+| `POST` | `/system-prompts` | Create a new version |
+| `POST` | `/system-prompts/:id/activate` | Set as the active system prompt |
+
+### 5.4 Dataset Export
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/export/jsonl` | Export all approved examples as LLaMA-Factory JSONL |
+| `GET` | `/export/stats` | Summary: approved/pending/rejected counts per tier |
+
+### 5.5 Screenshot Service (Proxy)
+
+The backend proxies screenshot requests so the frontend never calls the screenshot service directly.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/screenshot` | Render code → STL → PNG. Body: `{ code, angles? }` |
+
+---
+
+## 6. Screenshot Service
+
+### 6.1 REST API
+
+**Base URL:** `http://screenshot-service:3002`
+
+#### `POST /screenshot`
+
+Request body:
+```json
+{
+  "stlBase64": "<base64-encoded STL file content>",
+  "width": 512,
+  "height": 512,
+  "angles": ["front", "top", "isometric"]
+}
+```
+
+Response (success `200`):
+```json
+{
+  "images": [
+    { "angle": "front",      "base64": "<PNG base64>" },
+    { "angle": "top",        "base64": "<PNG base64>" },
+    { "angle": "isometric",  "base64": "<PNG base64>" }
+  ]
+}
+```
+
+Response (error `400` / `500`):
+```json
+{
+  "error": "human-readable message",
+  "type": "client" | "server"
+}
+```
+
+#### `GET /health`
+
+Returns `{ "status": "ok" }` when Puppeteer is ready.
+
+### 6.2 Implementation
+
+- Node.js 20 + Express
+- Puppeteer with `skipDownload: true`; Chromium provided by `chromium` package
+- Three.js loaded into the headless browser page via bundled HTML template
+- Three angles: `front` (camera at +Z), `top` (camera at +Y), `isometric` (+X+Y+Z diagonal)
+- STL is injected as a `data:` URI; `window.renderImage(stlDataUri, angle)` returns a PNG data URL
+- 30-second timeout per angle; 10-second Puppeteer launch timeout
+- Docker flags: `--no-sandbox`, `--disable-setuid-sandbox`, `--use-gl=angle`, `--use-angle=swiftshader`
+
+### 6.3 Dockerfile
+
+```
+Base: node:20-alpine
+Install: chromium package + dependencies
+Copy: service source + bundled Three.js HTML template
+Port: 3002
+```
+
+### 6.4 Docker Compose Addition
+
+```yaml
+screenshot-service:
+  build:
+    context: ./services/screenshot-service
+  ports:
+    - "3002:3002"
+  environment:
+    - NODE_ENV=production
+  restart: unless-stopped
+```
+
+---
+
+## 7. Build123d System Prompt
+
+The system prompt (`src/data/build123d-system-prompt.md`) is the single most critical asset. It must be a **dense, self-contained reference** that teaches the LLM everything it needs to generate correct Build123d code without hallucination.
+
+### 7.1 Required Sections
+
+1. **Role and output contract** — LLM identity, what it must produce, exact format requirements.
+2. **Code structure requirements** — mandatory patterns (BuildPart context, single export call, no `print()`, no file I/O beyond export).
+3. **Import conventions** — `from build123d import *` is the only supported import.
+4. **Build contexts** — `BuildPart`, `BuildSketch`, `BuildLine`; how nesting works; what `mode=Mode.ADD/SUBTRACT/INTERSECT` means.
+5. **Primitives** — complete list with correct signatures, default values, and units (mm).
+6. **Location and orientation** — `Location`, `Axis`, `Plane`, `Vector`, `Rotation`; how to translate/rotate objects; `with Locations(...)` context.
+7. **Sketch operations** — `Circle`, `Rectangle`, `RegularPolygon`, `Ellipse`, `Polyline`, `Spline`, `make_face()`, `make_hull()`.
+8. **3D operations** — `extrude`, `revolve`, `loft`, `sweep`; required arguments and return types.
+9. **Boolean operations** — `fuse`, `cut`, `intersect`; usage with `mode=Mode.SUBTRACT` inside context vs explicit calls.
+10. **Edge/face selection** — `.edges()`, `.faces()`, `.vertices()`; filter by `Axis`, `GeomType`, `Select`; sort patterns.
+11. **Fillets and chamfers** — `fillet`, `chamfer`; selecting all edges vs specific edges.
+12. **Shell and offset** — `shell` for hollow parts; `offset` for expanding/contracting faces.
+13. **Arrays and patterns** — `GridLocations`, `PolarLocations`, `Locations` with multiple points.
+14. **Export functions** — `export_step`, `export_stl`, `export_3mf`; file naming conventions.
+15. **Common mistakes to avoid** — curated list of known LLM failure modes (wrong class names, missing context managers, calling methods on wrong types, etc.).
+
+### 7.2 Format Requirements Embedded in the Prompt
+
+The prompt must specify exactly:
+- Code must be executable as a standalone Python script.
+- Must begin with `from build123d import *`.
+- Must produce exactly one STEP file via `export_step(part.part, "{filename}.step")`.
+- The filename is injected by the caller; the LLM must use it as a template variable.
+- No interactive elements, no user input, no `import sys`, no `matplotlib`.
+- All dimensions in millimeters unless explicitly stated otherwise.
+- Output must be wrapped in a fenced code block: ` ```python ... ``` `.
+
+### 7.3 Example Selection for Few-Shot Context
+
+When generating for a category of rank `N` in tier `T`:
+- Retrieve approved examples from categories with rank `< N`, ordered by tier descending.
+- Take at most **3 examples** from the immediately adjacent tier (`T-1`), and **1 example** from each earlier tier (up to 3 earlier tiers).
+- Maximum total: **6 examples** injected into the prompt.
+- Each example is included in full (never truncated).
+- Examples are formatted as: description header + fenced Python code block.
+
+---
+
+## 8. Complexity Curriculum (50 Categories)
+
+### Tier 0 — Primitives and Build Contexts (1–8)
+
+| Rank | Name | Description |
+|------|------|-------------|
+| 1 | Box primitive | Single Box with explicit dimensions |
+| 2 | Cylinder primitive | Single Cylinder; demonstrate arc_size for partial cylinder |
+| 3 | Sphere primitive | Single Sphere; demonstrate arc_size parameters |
+| 4 | Cone primitive | Cone (pointed) and truncated cone (top_radius > 0) |
+| 5 | Torus primitive | Torus (donut) demonstrating major/minor radius |
+| 6 | Multi-primitive positioning | 2–3 primitives placed using `with Locations(...)` |
+| 7 | Sketch basics | BuildSketch with Circle, Rectangle, RegularPolygon; make_face |
+| 8 | BuildPart context deep dive | Nested BuildPart + BuildSketch + BuildLine; mode=Mode.ADD/SUBTRACT |
+
+### Tier 1 — Core Operations (9–18)
+
+| Rank | Name | Description |
+|------|------|-------------|
+| 9  | Extrude from sketch | Rectangle sketch → extruded solid |
+| 10 | Extrude with taper | Tapered extrusion using `taper` parameter |
+| 11 | Revolve | L-profile revolved around axis |
+| 12 | Loft | Two different profiles lofted into solid |
+| 13 | Sweep | Circle profile swept along a curved path |
+| 14 | Boolean union | Two overlapping solids fused |
+| 15 | Boolean difference | Cylinder subtracted from box (through-hole) |
+| 16 | Boolean intersection | Keep only overlapping volume |
+| 17 | Fillet all edges | Box with all edges rounded |
+| 18 | Chamfer selected edges | Box with chamfered top edges only |
+
+### Tier 2 — Simple Composite Objects (19–28)
+
+| Rank | Name | Description |
+|------|------|-------------|
+| 19 | Bracket with holes | Flat plate with 4 through-holes via GridLocations |
+| 20 | Bushing | Cylinder with concentric through-hole |
+| 21 | L-bracket | Two rectangular extrusions joined at 90° |
+| 22 | T-connector | Three-way T-shaped solid |
+| 23 | Rounded box | Box with fillet on all edges |
+| 24 | Stepped shaft | Multiple-diameter cylinder (3 steps) |
+| 25 | Flat washer | Ring/annulus (cylinder − cylinder) |
+| 26 | Hex prism | Extruded hexagonal sketch |
+| 27 | Simple hook | Swept curve forming a hook shape |
+| 28 | Hollow box (shell) | Box with open top via shell operation |
+
+### Tier 3 — Mechanical Components (29–38)
+
+| Rank | Name | Description |
+|------|------|-------------|
+| 29 | Hex bolt head | Hexagonal prism + cylinder shank |
+| 30 | Hex nut | Hexagonal prism with centered threaded hole |
+| 31 | Flat head screw | Countersunk head + shank |
+| 32 | Simple spur gear | Involute tooth profile revolved into gear |
+| 33 | Keyed shaft | Shaft with keyway slot cut along length |
+| 34 | Simple hinge | Two barrel halves + pin |
+| 35 | Clip / snap fit | Cantilevered snap beam on a plate |
+| 36 | Spring coil | Sweep of circle along helical path |
+| 37 | Pulley | Grooved cylinder with central bore |
+| 38 | Bearing housing | Cylindrical housing with two flange holes |
+
+### Tier 4 — Electronic / Enclosure Components (39–46)
+
+| Rank | Name | Description |
+|------|------|-------------|
+| 39 | PCB standoff | Hex standoff with M3 thread pocket |
+| 40 | DIN rail clip | Standard DIN 35 rail mounting clip |
+| 41 | Cable tie mount | Surface mount with cable tie loop |
+| 42 | Panel cutout frame | Rectangular panel with lip for display |
+| 43 | M3 insert pocket | Cylindrical boss with blind hole for heat insert |
+| 44 | Raspberry Pi camera mount | Plate matching Pi Camera v3 hole pattern |
+| 45 | OLED display bezel | Bezel with cutout for 0.96" OLED |
+| 46 | Panel mounting bracket | L-bracket with counterbore holes |
+
+### Tier 5 — Complex Assemblies (47–50)
+
+| Rank | Name | Description |
+|------|------|-------------|
+| 47 | Raspberry Pi 5 — bottom tray | Bottom half of Pi 5 enclosure (PCB standoffs, port cutouts) |
+| 48 | Raspberry Pi 5 — lid | Top half with ventilation slots and GPIO access |
+| 49 | Arduino Mega enclosure | Full enclosure with USB, power, and header access |
+| 50 | Generic project box | Parametric enclosure with configurable cable glands |
+
+---
+
+## 9. Code Generation Pipeline
+
+For each category, the workbench runs the following pipeline:
+
+```
+1. SELECT CATEGORY (human picks which category to work on next)
+         │
+         ▼
+2. BUILD PROMPT
+   - Load active system prompt
+   - Select up to 6 approved examples from lower-rank categories
+   - Compose: system_prompt + examples + category_description + hint
+         │
+         ▼
+3. GENERATE CODE (LLM via Vercel AI SDK)
+   - Provider: configured codegen provider (Anthropic/OpenAI/Ollama)
+   - Extract Python code from fenced block
+         │
+         ▼
+4. RENDER (Build123d service)
+   - POST /render/ with code + filename
+   - On error: capture error message, increment iteration count
+   - If render_error AND iteration < MAX_AUTO_FIX_ITERATIONS (5):
+       → LLM receives error + previous code → generates fix → back to step 4
+   - If iteration >= MAX_AUTO_FIX_ITERATIONS: mark as needs_manual_fix
+         │
+         ▼
+5. SCREENSHOT (screenshot-service)
+   - POST /screenshot with stlBase64 + angles [front, top, isometric]
+   - Store three PNG images on the example record
+         │
+         ▼
+6. HUMAN REVIEW
+   - Admin views code + three screenshots
+   - Decision: APPROVE, REJECT (with note), or EDIT CODE (manual fix → back to step 4)
+         │
+         ▼
+7. ON APPROVE
+   - example.approval_status = 'approved'
+   - category.status = 'approved'
+   - Example is now available as few-shot context for higher-rank categories
+```
+
+### 9.1 Auto-Fix Loop Detail
+
+When a render error occurs:
+
+```
+Fix prompt structure:
+  [system_prompt]
+  [prior approved examples]
+
+  ## Previous code that failed to render:
+  ```python
+  {failed_code}
+  ```
+
+  ## Render error:
+  {error_message}
+
+  Fix the code above. Preserve the intended geometry.
+  Return only the corrected Python code in a fenced code block.
+```
+
+Each fix attempt increments `iteration` and creates a new `workbench_examples` row (preserving history). The previous failed code is stored, never overwritten.
+
+---
+
+## 10. Frontend Design
+
+### 10.1 Routes
+
+| Path | Component | Description |
+|------|-----------|-------------|
+| `/workbench` | `WorkbenchPage` | Category list overview |
+| `/workbench/:categoryId` | `WorkbenchCategoryPage` | Category detail with editor + previews |
+
+Both routes are guarded by `AdminRouteGuard`.
+
+Navigation: added to the admin section of `authenticatedNavGroups` (visible only when `isAdmin`).
+
+### 10.2 Workbench Page (`/workbench`)
+
+**Top section:**
+- `PageHeader` with "LLM Workbench" title and "Seed Categories" button (triggers `/categories/seed`).
+- Stats bar: counts per tier and approval status (from `/export/stats`).
+
+**Category table:**
+- Columns: Rank, Tier badge, Name, Status badge, Examples count, Actions.
+- Filter by tier and status.
+- Click row → navigate to category detail.
+- "Generate" action button on each row for quick dispatch.
+
+### 10.3 Category Page (`/workbench/:categoryId`)
+
+**Left panel (40%):**
+- Category name, description, hint.
+- Status badge + "Mark as Skipped" action.
+- Code editor (`<textarea>` or basic code editor with monospace font).
+- Action buttons: "Generate", "Render + Screenshot", "Approve", "Reject".
+- Iteration counter: "Attempt 3 / 5 max auto-fix".
+
+**Right panel (60%):**
+- Three screenshot thumbnails: Front, Top, Isometric.
+- Click to expand to full size.
+- Render status badge (pending / rendering / success / error).
+- Render error message (if any), copyable.
+
+**History section (below):**
+- Table of all previous iterations for this category.
+- Columns: Iteration, Status, Approved, Render Status, Created at, View Code.
+
+### 10.4 Dataset Export Panel (in Admin tab or separate `/workbench/export`)
+
+- Stats: total approved examples, breakdown by tier.
+- "Export JSONL" button → downloads file.
+- "View Active System Prompt" → opens system prompt text in a read-only viewer.
+
+---
+
+## 11. Training Dataset Format
+
+Each approved example becomes one training record in the fine-tuning dataset.
+
+### 11.1 JSONL Structure (LLaMA-Factory conversation format)
+
+```json
+{
+  "conversations": [
+    {
+      "from": "system",
+      "value": "{full Build123d system prompt text}"
+    },
+    {
+      "from": "human",
+      "value": "{category description + any additional context}"
+    },
+    {
+      "from": "gpt",
+      "value": "```python\n{approved code}\n```"
+    }
+  ]
+}
+```
+
+One JSON object per line. File: `workbench-dataset-{timestamp}.jsonl`.
+
+### 11.2 Example Count Targets
+
+| Tier | Categories | Target examples/category | Target total |
+|------|-----------|--------------------------|--------------|
+| 0 | 8 | 3 | 24 |
+| 1 | 10 | 3 | 30 |
+| 2 | 10 | 2 | 20 |
+| 3 | 10 | 2 | 20 |
+| 4 | 8 | 2 | 16 |
+| 5 | 4 | 2 | 8 |
+| **Total** | **50** | | **~118** |
+
+A dataset of ~100–150 high-quality, validated examples is the minimum viable fine-tuning set. Quality over quantity: one well-validated example is worth 10 generated-but-unchecked examples.
+
+---
+
+## 12. Implementation Phases
+
+### Phase 1 — Screenshot Service (current)
+
+- [ ] Create `services/screenshot-service/` directory
+- [ ] Node.js + Express app with Puppeteer + Three.js HTML template
+- [ ] `POST /screenshot` endpoint accepting STL base64
+- [ ] `GET /health` endpoint
+- [ ] Dockerfile
+- [ ] Add to `docker-compose.yml`
+- [ ] Add `SCREENSHOT_SERVICE_URL` env var and config entry
+- [ ] Verify build succeeds
+
+### Phase 2 — Backend Workbench API
+
+- [ ] DB migration: `workbench_categories`, `workbench_examples`, `workbench_system_prompts`
+- [ ] Write comprehensive `build123d-system-prompt.md` asset
+- [ ] Seed script for 50 categories
+- [ ] `workbench.service.ts` (generation pipeline logic)
+- [ ] `workbench.routes.ts` under `/api/admin/workbench`
+- [ ] Screenshot proxy via screenshot service
+- [ ] Dataset export endpoint (JSONL)
+- [ ] Verify backend builds
+
+### Phase 3 — Frontend Workbench UI
+
+- [ ] `WorkbenchPage` component (category list + stats)
+- [ ] `WorkbenchCategoryPage` component (editor + screenshots + history)
+- [ ] Add `/workbench` route to `app.tsx` (admin-guarded)
+- [ ] Add "Workbench" to admin nav group
+- [ ] Frontend API client: `workbench.api.ts`
+- [ ] Verify frontend builds
+
+### Phase 4 — Polish & Dataset Pipeline
+
+- [ ] System prompt editor in UI
+- [ ] Multiple examples per category (rerun for additional variety)
+- [ ] Batch generation mode (run through all `pending` categories automatically)
+- [ ] Export preview (show sample records before downloading)
+- [ ] JSONL format validation on export
+
+---
+
+## 13. Open Questions / Decisions Deferred
+
+| # | Question | Status |
+|---|----------|--------|
+| 1 | Fine-tuning framework (LLaMA-Factory vs Axolotl) | Deferred — decide when training begins |
+| 2 | Multiple approved examples per category or one best example? | Start with one; extend in Phase 4 |
+| 3 | Should the auto-fix loop stream tokens back to the UI? | Nice-to-have; Phase 3 polish |
+| 4 | Rate limiting on `/generate` endpoint? | Add in Phase 2 (reuse existing rate limit infra) |
+| 5 | Where to store generated STL/STEP files for workbench? | Under `/data/storage/workbench/{exampleId}/` |
+| 6 | System prompt versioning for A/B testing? | Phase 4 |
+
+---
+
+*End of Design Document v0.1*

--- a/docs/build123d-llm-workbench.md
+++ b/docs/build123d-llm-workbench.md
@@ -37,7 +37,7 @@ The path from 1,000 to 10,000 is re-running each prompt with varied temperature/
 
 - Admin-only feature, accessible at `/workbench` in the frontend.
 - Backend API under `/api/admin/workbench/`.
-- New standalone Docker service: `screenshot-service` (Puppeteer + Three.js STL renderer).
+- New standalone Docker service: `stl-rendering-service` (Puppeteer + Three.js STL/3MF renderer).
 - New database tables in the existing PostgreSQL instance.
 - No changes to the user-facing Chat3D experience.
 
@@ -49,11 +49,11 @@ The path from 1,000 to 10,000 is re-running each prompt with varied temperature/
 
 The workbench reuses the existing auth system (admin role), LLM infrastructure (Vercel AI SDK), Build123d render service, and database. A separate app would duplicate all of this.
 
-### 2.2 Screenshot Service as a Separate Docker Container
+### 2.2 STL Rendering Service as a Separate Docker Container
 
-Puppeteer + Three.js requires Chromium — inappropriate to include in the main backend image. Extracted as `services/screenshot-service/`. Implementation derived from `chat3d-docker` project (`imageRenderer.ts`).
+Puppeteer + Three.js requires Chromium — inappropriate to include in the main backend image. Extracted as `services/stl-rendering-service/`. Implementation derived from `chat3d-docker` project (`imageRenderer.ts`).
 
-- New env var: `SCREENSHOT_SERVICE_URL` (default: `http://screenshot-service:3002`)
+- New env var: `STL_RENDERING_SERVICE_URL` (default: `http://stl-rendering-service:3002`)
 
 ### 2.3 Categories Are Complexity Groups, Not Individual Examples
 
@@ -131,7 +131,7 @@ Colors are preserved in **3MF export** (`export_3mf`) but not in STL. Approximat
 
 For colored examples:
 - The generation prompt instructs the LLM to use `Color` and export 3MF instead of STEP
-- The screenshot service accepts 3MF via `ThreeMFLoader` (already used by the Chat3D frontend) in addition to STL
+- The STL rendering service accepts 3MF via `ThreeMFLoader` (already used by the Chat3D frontend) in addition to STL
 - The VLM can then evaluate color correctness alongside shape
 
 ---
@@ -142,26 +142,26 @@ For colored examples:
 graph TD
     Admin["Admin Browser\n/workbench"] -->|JWT, admin role| Backend["Backend\n:3001 /api/admin/workbench"]
     Backend -->|POST /render/| Build123d["Build123d Service\n:30222"]
-    Backend -->|POST /screenshot| Screenshot["Screenshot Service\n:3002"]
+    Backend -->|POST /render| STLRenderer["STL Rendering Service\n:3002"]
     Backend -->|Image search| ImageSearch["Bing/Google\nImage Search API"]
     Backend -->|VLM evaluate| LLM_VLM["VLM Provider\n(Anthropic/OpenAI)"]
     Backend -->|generateText codegen| LLM_Codegen["Codegen LLM\n(configured provider)"]
     Backend <-->|SQL| DB["PostgreSQL\n:5432"]
     Build123d -->|.stl/.step| Storage["/data/storage/workbench/"]
-    Screenshot -->|PNG base64| Backend
+    STLRenderer -->|PNG base64| Backend
 ```
 
 ### New Docker Services
 
 | Service | Port | Purpose |
 |---------|------|---------|
-| `screenshot-service` | 3002 | STL → PNG via Puppeteer + Three.js |
+| `stl-rendering-service` | 3002 | STL/3MF → PNG via Puppeteer + Three.js |
 
 ### New Environment Variables
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `SCREENSHOT_SERVICE_URL` | `http://screenshot-service:3002` | Screenshot service URL |
+| `STL_RENDERING_SERVICE_URL` | `http://stl-rendering-service:3002` | STL rendering service URL |
 | `EVAL_VLM_PROVIDER` | `anthropic` | VLM provider for visual evaluation |
 | `EVAL_VLM_MODEL` | `claude-sonnet-4-6` | VLM model name |
 | `IMAGE_SEARCH_PROVIDER` | `bing` | Image search provider (`bing` \| `google` \| `none`) |
@@ -322,7 +322,7 @@ This is the core loop. For each `(category, prompt)` pair:
 │   render_error, iter < MAX_FIX ────────────────────────────────────────┤
 │   render_error, iter ≥ MAX_FIX → FLAG human review                     │
 ▼                                                                        │
-[3] SCREENSHOT (screenshot-service)                                      │
+[3] SCREENSHOT (stl-rendering-service)                                      │
 │   3 angles: front, top, isometric                                      │
 ▼                                                                        │
 [4] VLM EVALUATE                                                         │
@@ -493,11 +493,11 @@ All routes under `/api/admin/workbench` require `requireAuth` + `requireRole("ad
 
 ---
 
-## 9. Screenshot Service
+## 9. STL Rendering Service
 
 ### 9.1 API
 
-**`POST /screenshot`**
+**`POST /render`**
 
 ```json
 // Request
@@ -654,12 +654,12 @@ All guarded by `AdminRouteGuard`. Navigation entry added to admin nav group.
 
 ## 14. Implementation Phases
 
-### Phase 1 — Screenshot Service
+### Phase 1 — STL Rendering Service
 
-- [ ] `services/screenshot-service/` — Node.js + Express + Puppeteer + Three.js template
-- [ ] `POST /screenshot` and `GET /health` endpoints
+- [ ] `services/stl-rendering-service/` — Node.js + Express + Puppeteer + Three.js template
+- [ ] `POST /render` and `GET /health` endpoints
 - [ ] Dockerfile + `docker-compose.yml` addition
-- [ ] `SCREENSHOT_SERVICE_URL` env var in backend config
+- [ ] `STL_RENDERING_SERVICE_URL` env var in backend config
 - [ ] Build verification
 
 ### Phase 2 — Curriculum Content
@@ -674,7 +674,7 @@ All guarded by `AdminRouteGuard`. Navigation entry added to admin nav group.
 - [ ] `workbench.service.ts` — generation pipeline, VLM evaluation, fix loop
 - [ ] `visual-eval.service.ts` — adapted from `chat3d-docker`, Vercel AI SDK, multi-provider
 - [ ] `workbench.routes.ts` under `/api/admin/workbench`
-- [ ] Screenshot service proxy
+- [ ] STL rendering service integration
 - [ ] JSONL export
 - [ ] Build verification
 

--- a/docs/build123d-llm-workbench.md
+++ b/docs/build123d-llm-workbench.md
@@ -1,6 +1,6 @@
 # Build123d LLM Workbench — Design Document
 
-> **Status:** Draft v0.1 — 2026-02-24
+> **Status:** Draft v0.2 — 2026-02-24
 > **Owner:** kreuzhofer
 > **Branch:** `claude/build123d-llm-workbench-Zzddt`
 
@@ -8,20 +8,30 @@
 
 ## 1. Overview & Goals
 
-The Build123d LLM Workbench is an admin-only feature within the Chat3D application. Its purpose is to generate, validate, and curate a high-quality dataset of Build123d Python code examples, which will be used to fine-tune an open-weight LLM specifically for 3D CAD code generation.
+The Build123d LLM Workbench is an admin-only feature within the Chat3D application. Its purpose is to generate, validate, and curate a high-quality dataset of Build123d Python code examples for fine-tuning an open-weight LLM specifically for 3D CAD code generation.
 
 ### Problem
 
-No currently available LLM generates reliable Build123d code out of the box. Build123d is a relatively niche Python CAD library, and models hallucinate incorrect class names, wrong argument order, and invalid geometry operations. A fine-tuned model with a well-curated dataset would dramatically improve code generation quality inside Chat3D.
+No currently available LLM generates reliable Build123d code out of the box. Build123d is a niche Python CAD library; models hallucinate incorrect class names, wrong argument order, and invalid geometry operations. A fine-tuned model with a well-curated dataset would dramatically improve code generation quality inside Chat3D.
 
 ### Solution
 
-A progressively structured dataset generation pipeline:
+A progressively structured, largely automated dataset generation pipeline:
 
-1. A **complexity curriculum** of 50 categories, ordered from simple primitives to complex assemblies.
-2. An **iterative code generation and validation loop** per category: generate → render → screenshot → human review → approve or fix.
-3. Validated examples from simpler categories **feed as few-shot context** into generation prompts for harder categories.
-4. Approved examples accumulate into an **exportable training dataset** for LLM fine-tuning.
+1. A **complexity curriculum** of ~11 categories, ordered from simple primitives to complex PCB cases.
+2. **100 user-facing example prompts per category** written upfront (natural language descriptions of objects, no code hints), stored as Markdown files in the repository.
+3. An **automated generation and evaluation loop**: generate code → render → screenshot → VLM evaluate → auto-approve or auto-fix.
+4. **Human review only for edge cases** that exhaust the auto-fix budget.
+5. Approved examples accumulate into an **exportable training dataset** for LLM fine-tuning.
+
+### Scale Targets
+
+| Milestone | Prompts | Target validated examples |
+|-----------|---------|--------------------------|
+| v1 (initial run) | ~1,100 (100 × 11 categories) | 1,000 |
+| Final | Same prompts, multiple generation seeds | 10,000 |
+
+The path from 1,000 to 10,000 is re-running each prompt with varied temperature/random seeds (9–10 generation passes per prompt), not writing more prompts.
 
 ### Scope
 
@@ -37,56 +47,92 @@ A progressively structured dataset generation pipeline:
 
 ### 2.1 Integrated into Chat3D, Not a Separate App
 
-The workbench reuses the existing auth system (admin role check), LLM infrastructure (Vercel AI SDK + provider configuration), Build123d render service, and database. A separate app would duplicate all of this for no benefit at this stage.
+The workbench reuses the existing auth system (admin role), LLM infrastructure (Vercel AI SDK), Build123d render service, and database. A separate app would duplicate all of this.
 
 ### 2.2 Screenshot Service as a Separate Docker Container
 
-The Puppeteer + Three.js STL-to-PNG renderer requires Chromium, which is a heavyweight dependency inappropriate to include in the main backend image. It is extracted as a standalone service:
+Puppeteer + Three.js requires Chromium — inappropriate to include in the main backend image. Extracted as `services/screenshot-service/`. Implementation derived from `chat3d-docker` project (`imageRenderer.ts`).
 
-- Keeps backend image lean.
-- Can be scaled or replaced independently (e.g., replace with a GPU renderer later).
-- Based on the implementation in the previous `chat3d-docker` project (`imageRenderer.ts`).
-- New environment variable: `SCREENSHOT_SERVICE_URL`.
+- New env var: `SCREENSHOT_SERVICE_URL` (default: `http://screenshot-service:3002`)
 
-### 2.3 Full Example Retrieval (No Chunking)
+### 2.3 Categories Are Complexity Groups, Not Individual Examples
 
-When selecting prior examples for few-shot context, we always retrieve **complete code examples**, never partial chunks. Chunking risks cutting off import statements, context managers, or the export call — making examples useless or misleading. We limit the number of examples injected rather than their size.
+Categories group examples by the Build123d concepts they exercise. There are ~11 categories, ordered by complexity from **Primitives** (1) to **PCB Cases** (10). Each category contains 100 user-facing example prompts. The curriculum controls what complexity of code the LLM learns to generate progressively.
 
-### 2.4 Human-in-the-Loop for Visual Validation
+### 2.4 Example Prompts Are User-Facing Natural Language
 
-The render service tells us if code is syntactically correct and produces a valid geometry file. It does **not** tell us if the object looks right. A cube with wrong proportions still renders successfully. Therefore:
+Example prompts describe what object to generate **from the user's perspective** — exactly what a user would type into Chat3D. They contain **no code hints, no API references, no implementation guidance**. That information lives in the system prompt.
 
-- Automated validation = no render error + no Python exception.
-- Visual validation = human reviews the screenshot and approves or rejects.
-- The LLM fix loop handles render errors automatically (up to `MAX_AUTO_FIX_ITERATIONS = 5`).
-- After that, human intervention is required.
+Good: `"A cylindrical spice jar lid with a flat top, 50mm diameter, 8mm tall, and a lip on the inside rim for friction fit."`
 
-### 2.5 System Prompt as a Versioned File Asset
+Bad: `"Use Cylinder(radius=25, height=8) with a shell operation to create a hollow lid."`
 
-The Build123d comprehensive system prompt is stored as a file asset in the backend (`src/data/build123d-system-prompt.md`), not in the database. This keeps it version-controlled, easily editable, and trivial to include in training data. A future extension could store multiple versions in the DB for A/B testing prompt strategies.
+### 2.5 VLM Auto-Evaluation Is the Primary Quality Gate
 
-### 2.6 Target Fine-Tuning Model: Qwen3-Coder-Next
+At 10,000 examples, manual review of every example is not feasible. The VLM (visual language model) evaluates rendered screenshots against the original prompt and scores 1–10. Score ≥ 7 triggers auto-approval. The auto-fix loop uses VLM suggestions to guide code correction. Humans review only examples that exhaust the fix budget.
 
-**Selected:** `Qwen3-Coder-Next` (released February 2026, Alibaba Qwen team)
+Derived from `chat3d-docker`'s `visualEval.ts`. Key adaptations:
+- Uses Vercel AI SDK (not raw OpenAI SDK) for consistency.
+- Supports both Anthropic and OpenAI as VLM providers.
+- Category complexity level is injected into the evaluation prompt.
+- Retry logic added (the original has none).
+
+### 2.6 System Prompt as a Versioned File Asset
+
+The comprehensive Build123d system prompt is stored as `src/data/build123d-system-prompt.md`, version-controlled, and seeded into the `workbench_system_prompts` table. It teaches the LLM the full Build123d API surface — it is not per-category. Future prompt versions can be stored for A/B testing.
+
+### 2.7 Full Example Retrieval for Few-Shot Context
+
+When selecting prior approved examples as few-shot context, always retrieve **complete code examples**, never chunks. Limit count (max 6) rather than size. Chunking risks truncating import statements, context managers, or export calls, making examples misleading.
+
+### 2.8 Target Fine-Tuning Model: Qwen3-Coder-Next
 
 | Property | Value |
 |----------|-------|
-| Architecture | MoE, 80B total params, **3B active per token** |
+| Architecture | MoE, 80B total, **3B active/token** |
 | Context window | 256K tokens |
-| 4-bit GGUF size | ~46 GB (fits single DGX Spark, 128 GB) |
-| BF16 LoRA training | Fits single DGX Spark with Unsloth |
-| SWE-Bench Verified | 70.6 (state of the art at its class) |
-| Inference throughput | ~10× vs dense equivalent |
+| 4-bit GGUF size | ~46 GB (fits single DGX Spark, 128 GB unified) |
+| BF16 LoRA training | Single DGX Spark with Unsloth |
+| MoE training speedup | 12× faster, 35% less VRAM (Unsloth Triton kernels) |
+| SWE-Bench Verified | 70.6 |
 | License | Apache 2.0 |
-| Fine-tuning framework | Unsloth (MoE training 12× faster, 35% less VRAM) |
+| Hardware | 2× DGX Spark (128 GB unified each, Blackwell GB10) |
 
-**Why not MiniMax-Text-01:** 456B total params, does not fit 128 GB DGX Spark even quantized, proprietary license, no public fine-tuning toolchain.
+Runner-up: `Qwen2.5-Coder-32B` (64 GB BF16, very mature fine-tuning toolchain).
 
-**Runner-up:** `Qwen2.5-Coder-32B` (64 GB BF16, Apache 2.0, very mature fine-tuning toolchain via LLaMA-Factory / Axolotl / Unsloth). Use if Qwen3-Coder-Next tooling proves immature.
+### 2.9 Training Dataset Output Format
 
-### 2.7 Training Dataset Output Format
+Deferred — will target LLaMA-Factory JSONL conversation format as default (compatible with broadest range of frameworks). Final decision when training begins.
 
-Deferred — will target LLaMA-Factory JSONL (conversation format with `system`/`user`/`assistant` roles) as the default, which is compatible with the broadest range of training frameworks. Final format decision comes when we begin training runs.
+### 2.10 Reference Images via Web Image Search
+
+To improve VLM evaluation quality, each prompt's key subject noun(s) are extracted and used to fetch 2–3 real-world reference images via the **Bing Image Search API** (generous free tier; configurable to Google Custom Search). These reference images are passed to the VLM alongside our 3D renders.
+
+The VLM evaluation prompt explicitly instructs: *"Our renders are untextured 3D models — evaluate geometric similarity only, not texture, color, or photorealism. Does this 3D model represent the same type of object shown in the reference images? Do the overall shape, proportions, and key features match?"*
+
+This gives strong grounding for abstract shape validation (e.g., "does this look like a mug?") without requiring photorealistic renders.
+
+Implementation:
+- New env vars: `IMAGE_SEARCH_PROVIDER` (`bing` | `google` | `none`), `IMAGE_SEARCH_API_KEY`, `IMAGE_SEARCH_ENGINE_ID` (Google only)
+- Subject extraction: simple noun extraction from prompt text (e.g., "a hex bolt" → query `"hex bolt 3D shape"`)
+- Cache search results by query string to avoid redundant API calls across iterations
+- Max 3 reference images per evaluation; fall back gracefully if search unavailable
+
+### 2.11 Color in Example Prompts
+
+Build123d supports per-part coloring via the `Color` class:
+```python
+part.part.color = Color("red")           # named color
+part.part.color = Color(0.8, 0.2, 0.2)  # RGB float
+part.part.color = Color(0.8, 0.2, 0.2, 0.7)  # RGBA
+```
+
+Colors are preserved in **3MF export** (`export_3mf`) but not in STL. Approximately **5% of example prompts** (55 of 1,100) will include color expectations, distributed toward higher complexity categories (7–11) where multi-part objects make color meaningful.
+
+For colored examples:
+- The generation prompt instructs the LLM to use `Color` and export 3MF instead of STEP
+- The screenshot service accepts 3MF via `ThreeMFLoader` (already used by the Chat3D frontend) in addition to STL
+- The VLM can then evaluate color correctness alongside shape
 
 ---
 
@@ -97,482 +143,449 @@ graph TD
     Admin["Admin Browser\n/workbench"] -->|JWT, admin role| Backend["Backend\n:3001 /api/admin/workbench"]
     Backend -->|POST /render/| Build123d["Build123d Service\n:30222"]
     Backend -->|POST /screenshot| Screenshot["Screenshot Service\n:3002"]
-    Backend -->|generateText| LLM["LLM Provider\n(Anthropic/OpenAI/Ollama)"]
+    Backend -->|Image search| ImageSearch["Bing/Google\nImage Search API"]
+    Backend -->|VLM evaluate| LLM_VLM["VLM Provider\n(Anthropic/OpenAI)"]
+    Backend -->|generateText codegen| LLM_Codegen["Codegen LLM\n(configured provider)"]
     Backend <-->|SQL| DB["PostgreSQL\n:5432"]
-    Build123d -->|.step/.stl| Storage["/data/storage"]
-    Screenshot -->|PNG| Backend
-    Backend -->|GET /api/files/| Admin
+    Build123d -->|.stl/.step| Storage["/data/storage/workbench/"]
+    Screenshot -->|PNG base64| Backend
 ```
 
 ### New Docker Services
 
-| Service | Image | Port | Purpose |
-|---------|-------|------|---------|
-| `screenshot-service` | Custom (Node 20 + Chromium) | 3002 | STL → PNG via Puppeteer + Three.js |
+| Service | Port | Purpose |
+|---------|------|---------|
+| `screenshot-service` | 3002 | STL → PNG via Puppeteer + Three.js |
 
 ### New Environment Variables
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `SCREENSHOT_SERVICE_URL` | `http://screenshot-service:3002` | URL of screenshot service |
+| `SCREENSHOT_SERVICE_URL` | `http://screenshot-service:3002` | Screenshot service URL |
+| `EVAL_VLM_PROVIDER` | `anthropic` | VLM provider for visual evaluation |
+| `EVAL_VLM_MODEL` | `claude-sonnet-4-6` | VLM model name |
+| `IMAGE_SEARCH_PROVIDER` | `bing` | Image search provider (`bing` \| `google` \| `none`) |
+| `IMAGE_SEARCH_API_KEY` | — | Bing or Google Custom Search API key |
+| `IMAGE_SEARCH_ENGINE_ID` | — | Google Custom Search engine ID (Google only) |
 
 ---
 
-## 4. Database Schema
+## 4. File Structure for Curriculum
 
-Three new tables, all scoped to admin use (no `owner_id` — they are global admin resources).
+Category definitions and example prompts live in the repository as Markdown files, version-controlled alongside the code.
 
-### 4.1 `workbench_categories`
+```
+workbench/
+  system-prompt.md              ← comprehensive Build123d reference for the LLM
+  categories/
+    01-primitives.md            ← 100 example prompts, complexity tier 1
+    02-sketch-operations.md     ← complexity tier 2
+    03-extrusions-revolutions.md
+    04-boolean-operations.md
+    05-surface-modifications.md
+    06-arrays-patterns.md
+    07-simple-objects.md
+    08-mechanical-components.md
+    09-electronic-components.md
+    10-enclosures.md
+    11-pcb-cases.md
+```
+
+### Category File Format
+
+```markdown
+---
+rank: 1
+name: Primitives
+complexity: 1
+description: >
+  Basic 3D primitive shapes available directly in build123d.
+  No sketches required — these are the fundamental building blocks.
+---
+
+## Examples
+
+1. A solid cube paperweight, 60mm on each side.
+
+2. A tall candleholder cylinder, 35mm outer diameter and 180mm tall.
+
+3. A decorative sphere 80mm in diameter.
+
+4. A chess pawn base — a truncated cone, 40mm bottom diameter,
+   20mm top diameter, 12mm tall.
+
+...
+```
+
+Prompts describe the **object and its visible properties** (shape, size, purpose), not how to build it. A seeder script reads all category files, parses frontmatter + numbered list of prompts, and populates `workbench_categories` and `workbench_example_prompts` tables.
+
+---
+
+## 5. Database Schema
+
+### 5.1 `workbench_categories`
 
 ```sql
 CREATE TABLE workbench_categories (
   id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  rank        INTEGER NOT NULL UNIQUE,           -- 1–50, sort order
-  tier        INTEGER NOT NULL,                  -- 0–5, complexity tier
+  rank        INTEGER NOT NULL UNIQUE,
   name        VARCHAR(255) NOT NULL,
-  description TEXT NOT NULL,                     -- human-readable goal description
-  hint        TEXT,                              -- optional: suggested approach / key APIs to use
-  status      VARCHAR(30) NOT NULL DEFAULT 'pending'
-              CHECK (status IN ('pending', 'in_progress', 'has_draft', 'approved', 'skipped')),
+  complexity  INTEGER NOT NULL CHECK (complexity BETWEEN 1 AND 10),
+  description TEXT NOT NULL,
   created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 ```
 
-**Statuses:**
-- `pending` — not started
-- `in_progress` — generation/validation is actively being worked on
-- `has_draft` — at least one example has been generated but none approved yet
-- `approved` — at least one example approved; category is usable as few-shot context
-- `skipped` — consciously excluded from the dataset
+### 5.2 `workbench_example_prompts`
 
-### 4.2 `workbench_examples`
+Stores the 100 user-facing prompts per category. This is the input side — the "questions" in the training dataset.
+
+```sql
+CREATE TABLE workbench_example_prompts (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  category_id  UUID NOT NULL REFERENCES workbench_categories(id) ON DELETE CASCADE,
+  index        INTEGER NOT NULL,          -- 1–100 within category
+  prompt       TEXT NOT NULL,             -- the user-facing natural language description
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (category_id, index)
+);
+
+CREATE INDEX idx_wb_prompts_category ON workbench_example_prompts(category_id);
+```
+
+### 5.3 `workbench_examples`
+
+Stores generated code attempts for each prompt. Multiple attempts per prompt (from fix iterations and re-runs for dataset expansion).
 
 ```sql
 CREATE TABLE workbench_examples (
-  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  category_id     UUID NOT NULL REFERENCES workbench_categories(id) ON DELETE CASCADE,
-  iteration       INTEGER NOT NULL DEFAULT 1,    -- auto-increments per category
-  code            TEXT NOT NULL,                 -- executable Build123d Python
-  render_status   VARCHAR(20) NOT NULL DEFAULT 'pending'
-                  CHECK (render_status IN ('pending', 'rendering', 'success', 'error')),
-  render_error    TEXT,                          -- error message if render failed
-  stl_path        TEXT,                          -- path to generated .stl file (for screenshot)
-  step_path       TEXT,                          -- path to generated .step file
-  screenshot_front    TEXT,                      -- base64 PNG, front angle
-  screenshot_top      TEXT,                      -- base64 PNG, top angle
-  screenshot_iso      TEXT,                      -- base64 PNG, isometric angle
-  approval_status VARCHAR(20) NOT NULL DEFAULT 'pending'
-                  CHECK (approval_status IN ('pending', 'approved', 'rejected')),
-  rejection_note  TEXT,                          -- human note if rejected
-  llm_model       VARCHAR(255),                  -- which model generated this
-  prompt_tokens   INTEGER,
-  completion_tokens INTEGER,
-  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  prompt_id           UUID NOT NULL REFERENCES workbench_example_prompts(id) ON DELETE CASCADE,
+  iteration           INTEGER NOT NULL DEFAULT 1,   -- attempt number (1 = first try)
+  generation_seed     INTEGER,                      -- random seed used for generation
+  code                TEXT NOT NULL,
+  render_status       VARCHAR(20) NOT NULL DEFAULT 'pending'
+                      CHECK (render_status IN ('pending', 'rendering', 'success', 'error')),
+  render_error        TEXT,
+  stl_path            TEXT,
+  step_path           TEXT,
+  screenshot_front    TEXT,    -- base64 PNG
+  screenshot_top      TEXT,    -- base64 PNG
+  screenshot_iso      TEXT,    -- base64 PNG
+  eval_score          INTEGER CHECK (eval_score BETWEEN 1 AND 10),
+  eval_issues         JSONB,   -- string[]
+  eval_suggestions    JSONB,   -- string[] — fed back into fix prompt
+  approval_status     VARCHAR(20) NOT NULL DEFAULT 'pending'
+                      CHECK (approval_status IN ('pending', 'auto_approved', 'human_approved', 'rejected')),
+  rejection_note      TEXT,
+  llm_model           VARCHAR(255),
+  vlm_model           VARCHAR(255),
+  prompt_tokens       INTEGER,
+  completion_tokens   INTEGER,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX idx_wb_examples_category ON workbench_examples(category_id);
+CREATE INDEX idx_wb_examples_prompt ON workbench_examples(prompt_id);
 CREATE INDEX idx_wb_examples_approval ON workbench_examples(approval_status);
+CREATE INDEX idx_wb_examples_eval_score ON workbench_examples(eval_score);
 ```
 
-### 4.3 `workbench_system_prompts`
+### 5.4 `workbench_system_prompts`
 
 ```sql
 CREATE TABLE workbench_system_prompts (
   id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   version     INTEGER NOT NULL UNIQUE,
   label       VARCHAR(255) NOT NULL,
-  content     TEXT NOT NULL,                     -- full system prompt text
-  is_active   BOOLEAN NOT NULL DEFAULT FALSE,    -- only one active at a time
+  content     TEXT NOT NULL,
+  is_active   BOOLEAN NOT NULL DEFAULT FALSE,
   created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 ```
 
-Seeded with `version=1` from `src/data/build123d-system-prompt.md` on first run. Later versions can be added via the UI for prompt A/B testing.
+---
+
+## 6. Automated Generation Pipeline
+
+This is the core loop. For each `(category, prompt)` pair:
+
+```
+┌─ [1] GENERATE code  ←─────────────────────────────────────────────────┐
+│     LLM (codegen provider)                                             │
+│     Input: system_prompt + up to 6 approved examples + user prompt     │
+│                                                                        │
+▼                                                                (fix prompt:
+[2] RENDER (Build123d service)                             render_error +
+│   success → [3]                                          vlm.suggestions)
+│   render_error, iter < MAX_FIX ────────────────────────────────────────┤
+│   render_error, iter ≥ MAX_FIX → FLAG human review                     │
+▼                                                                        │
+[3] SCREENSHOT (screenshot-service)                                      │
+│   3 angles: front, top, isometric                                      │
+▼                                                                        │
+[4] VLM EVALUATE                                                         │
+│   Input: user prompt + 3 screenshots + category complexity level        │
+│   Output: { score: 1–10, issues: string[], suggestions: string[] }     │
+│                                                                        │
+├── score ≥ 7:  AUTO-APPROVE → training dataset ✓                        │
+│                                                                        │
+├── score < 7, iter < MAX_FIX ───────────────────────────────────────────┘
+│
+└── score < 7, iter ≥ MAX_FIX → FLAG for human review
+```
+
+**MAX_FIX_ITERATIONS = 5**
+
+The fix prompt combines both render errors and VLM visual suggestions, giving the code-generation LLM precise, actionable feedback on both syntactic and visual failures in a single unified loop.
+
+### Fix Prompt Structure
+
+```
+{system_prompt}
+
+{prior approved few-shot examples}
+
+## Previous code (attempt {N}):
+```python
+{failed_code}
+```
+
+## Problems to fix:
+{render_error if any}
+{vlm.issues formatted as bullet list if any}
+
+## Suggested corrections:
+{vlm.suggestions formatted as bullet list if any}
+
+Fix the code. Preserve the intended geometry described in the original request.
+Return only the corrected Python code in a fenced code block.
+
+## Original request:
+{user_prompt}
+```
 
 ---
 
-## 5. API Contract
+## 7. Visual Evaluation (VLM)
 
-All routes under `/api/admin/workbench` require `requireAuth` + `requireRole("admin")` middleware.
+### 7.1 Approach
 
-### 5.1 Categories
+Derived from `chat3d-docker` (`api/src/services/visualEval.ts` + `api/src/prompts/visualEval.ts`). The original uses GPT-4o via raw OpenAI SDK. We adapt it to use the Vercel AI SDK with multi-provider support.
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/categories` | List all categories (sorted by rank) |
-| `GET` | `/categories/:id` | Get category + its examples |
-| `POST` | `/categories` | Create a category (manual or bulk seed) |
-| `PATCH` | `/categories/:id` | Update status, hint, name, description |
-| `POST` | `/categories/seed` | Seed the default 50-category curriculum |
+### 7.2 Evaluation Prompt Structure
 
-### 5.2 Examples
+The VLM receives:
+- **System prompt**: role definition, scoring rubric, output format requirement
+- **User message**: evaluation instruction + model images (3× `image_url` blocks at `detail: 'high'`) + optional reference image
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/examples/:id` | Get a single example (with screenshots) |
-| `POST` | `/examples/generate` | Generate a new example for a category (LLM + render + screenshot) |
-| `POST` | `/examples/:id/render` | Re-render an existing example's code |
-| `POST` | `/examples/:id/screenshot` | Re-screenshot an already-rendered example |
-| `PATCH` | `/examples/:id/approve` | Approve an example |
-| `PATCH` | `/examples/:id/reject` | Reject an example with optional note |
-| `PATCH` | `/examples/:id/code` | Update code manually (for human fixes) |
+System prompt template:
+```
+You are a 3D model quality evaluator for Build123d CAD models.
 
-### 5.3 System Prompts
+The user requested: "{user_prompt}"
+Category: {category_name} (complexity level {complexity}/10)
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/system-prompts` | List all system prompt versions |
-| `GET` | `/system-prompts/active` | Get the currently active system prompt |
-| `POST` | `/system-prompts` | Create a new version |
-| `POST` | `/system-prompts/:id/activate` | Set as the active system prompt |
+Evaluate the rendered 3D model shown in the images across three dimensions:
+- Shape: Is the overall shape correct? Missing or extra geometry?
+- Proportions: Are relative sizes of components correct?
+- Features: Are requested details present and accurate?
 
-### 5.4 Dataset Export
+Score the model from 1 to 10:
+- 1–3: Poor — major elements missing or wrong shape
+- 4–6: Partial — some elements correct, significant issues
+- 7–8: Good — correct overall, minor issues only
+- 9–10: Excellent — accurate representation of the request
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/export/jsonl` | Export all approved examples as LLaMA-Factory JSONL |
-| `GET` | `/export/stats` | Summary: approved/pending/rejected counts per tier |
+Adjust your expectations to the category complexity level. A complexity-1 primitive
+category only needs to demonstrate the basic shape correctly. A complexity-10 PCB case
+must have accurate port cutouts, standoff placement, and structural features.
 
-### 5.5 Screenshot Service (Proxy)
+Our renders are untextured 3D models. If reference images are provided, evaluate
+geometric similarity only — not texture, color (unless the prompt requests color),
+or photorealism. Focus on: Does this 3D model represent the same type of object?
+Do the overall shape, proportions, and key features match?
 
-The backend proxies screenshot requests so the frontend never calls the screenshot service directly.
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `POST` | `/screenshot` | Render code → STL → PNG. Body: `{ code, angles? }` |
-
----
-
-## 6. Screenshot Service
-
-### 6.1 REST API
-
-**Base URL:** `http://screenshot-service:3002`
-
-#### `POST /screenshot`
-
-Request body:
-```json
+Return JSON only:
 {
-  "stlBase64": "<base64-encoded STL file content>",
+  "score": <integer 1–10>,
+  "issues": ["<specific visual problem>", ...],
+  "suggestions": ["<build123d code-level fix>", ...]
+}
+```
+
+### 7.3 Provider Configuration
+
+```typescript
+// env vars: EVAL_VLM_PROVIDER (anthropic | openai), EVAL_VLM_MODEL
+// Defaults: anthropic / claude-sonnet-4-6
+// Fallback: openai / gpt-4o if Anthropic key not present
+```
+
+Uses `generateText()` from Vercel AI SDK with image content parts — consistent with the rest of the codebase. The `response_format: { type: 'json_object' }` mode is available via the SDK for both providers.
+
+### 7.4 Response Parsing
+
+Three-level fallback chain (preserved from original):
+1. Extract JSON from markdown code fence if present
+2. Direct `JSON.parse`
+3. Regex extraction of score/issues/suggestions from unstructured text
+
+Plus: retry logic (up to 2 retries on API failure before returning error result with score 1).
+
+### 7.5 Auto-Approval Threshold
+
+| Score | Action |
+|-------|--------|
+| ≥ 7 | `auto_approved` — enters training dataset immediately |
+| 4–6 | Trigger fix loop with VLM suggestions |
+| 1–3 | Trigger fix loop; if MAX_FIX exhausted, flag for human review |
+
+Human `human_approved` status available for examples that were manually reviewed.
+
+---
+
+## 8. API Contract
+
+All routes under `/api/admin/workbench` require `requireAuth` + `requireRole("admin")`.
+
+### 8.1 Categories & Prompts
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/categories` | List all categories with prompt counts and approval stats |
+| `GET` | `/categories/:id/prompts` | List prompts for a category with their example counts |
+| `POST` | `/categories/seed` | Seed categories + prompts from `workbench/categories/*.md` |
+
+### 8.2 Generation & Evaluation
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/generate` | Generate + render + screenshot + VLM eval for one prompt. Body: `{ promptId }` |
+| `POST` | `/generate/batch` | Queue batch generation for all pending prompts in a category |
+| `GET` | `/jobs/:jobId` | Poll batch job status |
+
+### 8.3 Examples
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/examples/:id` | Get a single example with screenshots and eval result |
+| `PATCH` | `/examples/:id/approve` | Human-approve an example |
+| `PATCH` | `/examples/:id/reject` | Reject an example with note |
+| `PATCH` | `/examples/:id/code` | Manually edit code, then re-render + re-evaluate |
+| `POST` | `/examples/:id/retry` | Re-run the generation pipeline for this prompt |
+
+### 8.4 System Prompts
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/system-prompts` | List versions |
+| `GET` | `/system-prompts/active` | Get active version |
+| `POST` | `/system-prompts/:id/activate` | Set active version |
+
+### 8.5 Export
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/export/jsonl` | Download approved examples as LLaMA-Factory JSONL |
+| `GET` | `/export/stats` | Counts per category: pending / auto_approved / human_approved / rejected / flagged |
+
+---
+
+## 9. Screenshot Service
+
+### 9.1 API
+
+**`POST /screenshot`**
+
+```json
+// Request
+{
+  "stlBase64": "<base64-encoded STL>",
   "width": 512,
   "height": 512,
   "angles": ["front", "top", "isometric"]
 }
-```
 
-Response (success `200`):
-```json
+// Response 200
 {
   "images": [
-    { "angle": "front",      "base64": "<PNG base64>" },
-    { "angle": "top",        "base64": "<PNG base64>" },
-    { "angle": "isometric",  "base64": "<PNG base64>" }
+    { "angle": "front",     "base64": "<PNG base64>" },
+    { "angle": "top",       "base64": "<PNG base64>" },
+    { "angle": "isometric", "base64": "<PNG base64>" }
   ]
 }
+
+// Response 400 / 500
+{ "error": "message", "type": "client" | "server" }
 ```
 
-Response (error `400` / `500`):
-```json
-{
-  "error": "human-readable message",
-  "type": "client" | "server"
-}
-```
+**`GET /health`** → `{ "status": "ok" }`
 
-#### `GET /health`
-
-Returns `{ "status": "ok" }` when Puppeteer is ready.
-
-### 6.2 Implementation
+### 9.2 Implementation
 
 - Node.js 20 + Express
-- Puppeteer with `skipDownload: true`; Chromium provided by `chromium` package
-- Three.js loaded into the headless browser page via bundled HTML template
-- Three angles: `front` (camera at +Z), `top` (camera at +Y), `isometric` (+X+Y+Z diagonal)
-- STL is injected as a `data:` URI; `window.renderImage(stlDataUri, angle)` returns a PNG data URL
-- 30-second timeout per angle; 10-second Puppeteer launch timeout
-- Docker flags: `--no-sandbox`, `--disable-setuid-sandbox`, `--use-gl=angle`, `--use-angle=swiftshader`
-
-### 6.3 Dockerfile
-
-```
-Base: node:20-alpine
-Install: chromium package + dependencies
-Copy: service source + bundled Three.js HTML template
-Port: 3002
-```
-
-### 6.4 Docker Compose Addition
-
-```yaml
-screenshot-service:
-  build:
-    context: ./services/screenshot-service
-  ports:
-    - "3002:3002"
-  environment:
-    - NODE_ENV=production
-  restart: unless-stopped
-```
+- Puppeteer (`skipDownload: true`); Chromium from system package
+- Three.js STLLoader in bundled HTML template (`stlRenderer.html`)
+- Camera positions: front (+Z), top (+Y), isometric (+X+Y+Z diagonal)
+- Docker flags: `--no-sandbox --disable-setuid-sandbox --use-gl=angle --use-angle=swiftshader`
+- Timeouts: 30s render per angle, 10s Puppeteer launch
 
 ---
 
-## 7. Build123d System Prompt
+## 10. Build123d System Prompt
 
-The system prompt (`src/data/build123d-system-prompt.md`) is the single most critical asset. It must be a **dense, self-contained reference** that teaches the LLM everything it needs to generate correct Build123d code without hallucination.
+`workbench/system-prompt.md` — the single shared technical reference injected into every code-generation prompt. Covers:
 
-### 7.1 Required Sections
+1. Role and output contract (what the LLM must produce, exact format)
+2. Import conventions (`from build123d import *`)
+3. Build contexts (`BuildPart`, `BuildSketch`, `BuildLine`) and nesting rules
+4. Location and orientation (`Location`, `Axis`, `Plane`, `Vector`, `Rotation`)
+5. All primitives with correct signatures and units (mm)
+6. Sketch primitives and operations (`make_face`, `make_hull`)
+7. 3D operations: extrude, revolve, loft, sweep
+8. Boolean operations and `Mode` enum
+9. Edge/face selection: `.edges()`, `.faces()`, filter methods
+10. Fillets, chamfers, shell, offset
+11. Arrays and patterns: `GridLocations`, `PolarLocations`, `Locations`
+12. Export functions: `export_step`, `export_stl`
+13. Common failure modes to avoid (curated from observed LLM mistakes)
 
-1. **Role and output contract** — LLM identity, what it must produce, exact format requirements.
-2. **Code structure requirements** — mandatory patterns (BuildPart context, single export call, no `print()`, no file I/O beyond export).
-3. **Import conventions** — `from build123d import *` is the only supported import.
-4. **Build contexts** — `BuildPart`, `BuildSketch`, `BuildLine`; how nesting works; what `mode=Mode.ADD/SUBTRACT/INTERSECT` means.
-5. **Primitives** — complete list with correct signatures, default values, and units (mm).
-6. **Location and orientation** — `Location`, `Axis`, `Plane`, `Vector`, `Rotation`; how to translate/rotate objects; `with Locations(...)` context.
-7. **Sketch operations** — `Circle`, `Rectangle`, `RegularPolygon`, `Ellipse`, `Polyline`, `Spline`, `make_face()`, `make_hull()`.
-8. **3D operations** — `extrude`, `revolve`, `loft`, `sweep`; required arguments and return types.
-9. **Boolean operations** — `fuse`, `cut`, `intersect`; usage with `mode=Mode.SUBTRACT` inside context vs explicit calls.
-10. **Edge/face selection** — `.edges()`, `.faces()`, `.vertices()`; filter by `Axis`, `GeomType`, `Select`; sort patterns.
-11. **Fillets and chamfers** — `fillet`, `chamfer`; selecting all edges vs specific edges.
-12. **Shell and offset** — `shell` for hollow parts; `offset` for expanding/contracting faces.
-13. **Arrays and patterns** — `GridLocations`, `PolarLocations`, `Locations` with multiple points.
-14. **Export functions** — `export_step`, `export_stl`, `export_3mf`; file naming conventions.
-15. **Common mistakes to avoid** — curated list of known LLM failure modes (wrong class names, missing context managers, calling methods on wrong types, etc.).
-
-### 7.2 Format Requirements Embedded in the Prompt
-
-The prompt must specify exactly:
-- Code must be executable as a standalone Python script.
-- Must begin with `from build123d import *`.
-- Must produce exactly one STEP file via `export_step(part.part, "{filename}.step")`.
-- The filename is injected by the caller; the LLM must use it as a template variable.
-- No interactive elements, no user input, no `import sys`, no `matplotlib`.
-- All dimensions in millimeters unless explicitly stated otherwise.
-- Output must be wrapped in a fenced code block: ` ```python ... ``` `.
-
-### 7.3 Example Selection for Few-Shot Context
-
-When generating for a category of rank `N` in tier `T`:
-- Retrieve approved examples from categories with rank `< N`, ordered by tier descending.
-- Take at most **3 examples** from the immediately adjacent tier (`T-1`), and **1 example** from each earlier tier (up to 3 earlier tiers).
-- Maximum total: **6 examples** injected into the prompt.
-- Each example is included in full (never truncated).
-- Examples are formatted as: description header + fenced Python code block.
+**Format requirements embedded in the prompt:**
+- Standalone executable Python script
+- Starts with `from build123d import *`
+- Produces exactly one STEP file: `export_step(part.part, "{filename}.step")`
+- No interactive elements, no `import sys`, no `matplotlib`
+- All dimensions in millimeters
+- Output wrapped in ` ```python ... ``` ` fenced code block
 
 ---
 
-## 8. Complexity Curriculum (50 Categories)
+## 11. Complexity Curriculum (11 Categories)
 
-### Tier 0 — Primitives and Build Contexts (1–8)
-
-| Rank | Name | Description |
-|------|------|-------------|
-| 1 | Box primitive | Single Box with explicit dimensions |
-| 2 | Cylinder primitive | Single Cylinder; demonstrate arc_size for partial cylinder |
-| 3 | Sphere primitive | Single Sphere; demonstrate arc_size parameters |
-| 4 | Cone primitive | Cone (pointed) and truncated cone (top_radius > 0) |
-| 5 | Torus primitive | Torus (donut) demonstrating major/minor radius |
-| 6 | Multi-primitive positioning | 2–3 primitives placed using `with Locations(...)` |
-| 7 | Sketch basics | BuildSketch with Circle, Rectangle, RegularPolygon; make_face |
-| 8 | BuildPart context deep dive | Nested BuildPart + BuildSketch + BuildLine; mode=Mode.ADD/SUBTRACT |
-
-### Tier 1 — Core Operations (9–18)
-
-| Rank | Name | Description |
-|------|------|-------------|
-| 9  | Extrude from sketch | Rectangle sketch → extruded solid |
-| 10 | Extrude with taper | Tapered extrusion using `taper` parameter |
-| 11 | Revolve | L-profile revolved around axis |
-| 12 | Loft | Two different profiles lofted into solid |
-| 13 | Sweep | Circle profile swept along a curved path |
-| 14 | Boolean union | Two overlapping solids fused |
-| 15 | Boolean difference | Cylinder subtracted from box (through-hole) |
-| 16 | Boolean intersection | Keep only overlapping volume |
-| 17 | Fillet all edges | Box with all edges rounded |
-| 18 | Chamfer selected edges | Box with chamfered top edges only |
-
-### Tier 2 — Simple Composite Objects (19–28)
-
-| Rank | Name | Description |
-|------|------|-------------|
-| 19 | Bracket with holes | Flat plate with 4 through-holes via GridLocations |
-| 20 | Bushing | Cylinder with concentric through-hole |
-| 21 | L-bracket | Two rectangular extrusions joined at 90° |
-| 22 | T-connector | Three-way T-shaped solid |
-| 23 | Rounded box | Box with fillet on all edges |
-| 24 | Stepped shaft | Multiple-diameter cylinder (3 steps) |
-| 25 | Flat washer | Ring/annulus (cylinder − cylinder) |
-| 26 | Hex prism | Extruded hexagonal sketch |
-| 27 | Simple hook | Swept curve forming a hook shape |
-| 28 | Hollow box (shell) | Box with open top via shell operation |
-
-### Tier 3 — Mechanical Components (29–38)
-
-| Rank | Name | Description |
-|------|------|-------------|
-| 29 | Hex bolt head | Hexagonal prism + cylinder shank |
-| 30 | Hex nut | Hexagonal prism with centered threaded hole |
-| 31 | Flat head screw | Countersunk head + shank |
-| 32 | Simple spur gear | Involute tooth profile revolved into gear |
-| 33 | Keyed shaft | Shaft with keyway slot cut along length |
-| 34 | Simple hinge | Two barrel halves + pin |
-| 35 | Clip / snap fit | Cantilevered snap beam on a plate |
-| 36 | Spring coil | Sweep of circle along helical path |
-| 37 | Pulley | Grooved cylinder with central bore |
-| 38 | Bearing housing | Cylindrical housing with two flange holes |
-
-### Tier 4 — Electronic / Enclosure Components (39–46)
-
-| Rank | Name | Description |
-|------|------|-------------|
-| 39 | PCB standoff | Hex standoff with M3 thread pocket |
-| 40 | DIN rail clip | Standard DIN 35 rail mounting clip |
-| 41 | Cable tie mount | Surface mount with cable tie loop |
-| 42 | Panel cutout frame | Rectangular panel with lip for display |
-| 43 | M3 insert pocket | Cylindrical boss with blind hole for heat insert |
-| 44 | Raspberry Pi camera mount | Plate matching Pi Camera v3 hole pattern |
-| 45 | OLED display bezel | Bezel with cutout for 0.96" OLED |
-| 46 | Panel mounting bracket | L-bracket with counterbore holes |
-
-### Tier 5 — Complex Assemblies (47–50)
-
-| Rank | Name | Description |
-|------|------|-------------|
-| 47 | Raspberry Pi 5 — bottom tray | Bottom half of Pi 5 enclosure (PCB standoffs, port cutouts) |
-| 48 | Raspberry Pi 5 — lid | Top half with ventilation slots and GPIO access |
-| 49 | Arduino Mega enclosure | Full enclosure with USB, power, and header access |
-| 50 | Generic project box | Parametric enclosure with configurable cable glands |
+| Rank | Category | Complexity | Prompts |
+|------|----------|-----------|---------|
+| 1 | Primitives | 1 | 100 |
+| 2 | Sketch Operations | 2 | 100 |
+| 3 | Extrusions & Revolutions | 3 | 100 |
+| 4 | Boolean Operations | 4 | 100 |
+| 5 | Surface Modifications | 5 | 100 |
+| 6 | Arrays & Patterns | 5 | 100 |
+| 7 | Simple Everyday Objects | 6 | 100 |
+| 8 | Mechanical Components | 7 | 100 |
+| 9 | Electronic Components | 8 | 100 |
+| 10 | Generic Enclosures | 9 | 100 |
+| 11 | PCB Cases | 10 | 100 |
+| **Total** | | | **1,100** |
 
 ---
 
-## 9. Code Generation Pipeline
+## 12. Training Dataset Format
 
-For each category, the workbench runs the following pipeline:
+### 12.1 JSONL (LLaMA-Factory conversation format)
 
-```
-1. SELECT CATEGORY (human picks which category to work on next)
-         │
-         ▼
-2. BUILD PROMPT
-   - Load active system prompt
-   - Select up to 6 approved examples from lower-rank categories
-   - Compose: system_prompt + examples + category_description + hint
-         │
-         ▼
-3. GENERATE CODE (LLM via Vercel AI SDK)
-   - Provider: configured codegen provider (Anthropic/OpenAI/Ollama)
-   - Extract Python code from fenced block
-         │
-         ▼
-4. RENDER (Build123d service)
-   - POST /render/ with code + filename
-   - On error: capture error message, increment iteration count
-   - If render_error AND iteration < MAX_AUTO_FIX_ITERATIONS (5):
-       → LLM receives error + previous code → generates fix → back to step 4
-   - If iteration >= MAX_AUTO_FIX_ITERATIONS: mark as needs_manual_fix
-         │
-         ▼
-5. SCREENSHOT (screenshot-service)
-   - POST /screenshot with stlBase64 + angles [front, top, isometric]
-   - Store three PNG images on the example record
-         │
-         ▼
-6. HUMAN REVIEW
-   - Admin views code + three screenshots
-   - Decision: APPROVE, REJECT (with note), or EDIT CODE (manual fix → back to step 4)
-         │
-         ▼
-7. ON APPROVE
-   - example.approval_status = 'approved'
-   - category.status = 'approved'
-   - Example is now available as few-shot context for higher-rank categories
-```
-
-### 9.1 Auto-Fix Loop Detail
-
-When a render error occurs:
-
-```
-Fix prompt structure:
-  [system_prompt]
-  [prior approved examples]
-
-  ## Previous code that failed to render:
-  ```python
-  {failed_code}
-  ```
-
-  ## Render error:
-  {error_message}
-
-  Fix the code above. Preserve the intended geometry.
-  Return only the corrected Python code in a fenced code block.
-```
-
-Each fix attempt increments `iteration` and creates a new `workbench_examples` row (preserving history). The previous failed code is stored, never overwritten.
-
----
-
-## 10. Frontend Design
-
-### 10.1 Routes
-
-| Path | Component | Description |
-|------|-----------|-------------|
-| `/workbench` | `WorkbenchPage` | Category list overview |
-| `/workbench/:categoryId` | `WorkbenchCategoryPage` | Category detail with editor + previews |
-
-Both routes are guarded by `AdminRouteGuard`.
-
-Navigation: added to the admin section of `authenticatedNavGroups` (visible only when `isAdmin`).
-
-### 10.2 Workbench Page (`/workbench`)
-
-**Top section:**
-- `PageHeader` with "LLM Workbench" title and "Seed Categories" button (triggers `/categories/seed`).
-- Stats bar: counts per tier and approval status (from `/export/stats`).
-
-**Category table:**
-- Columns: Rank, Tier badge, Name, Status badge, Examples count, Actions.
-- Filter by tier and status.
-- Click row → navigate to category detail.
-- "Generate" action button on each row for quick dispatch.
-
-### 10.3 Category Page (`/workbench/:categoryId`)
-
-**Left panel (40%):**
-- Category name, description, hint.
-- Status badge + "Mark as Skipped" action.
-- Code editor (`<textarea>` or basic code editor with monospace font).
-- Action buttons: "Generate", "Render + Screenshot", "Approve", "Reject".
-- Iteration counter: "Attempt 3 / 5 max auto-fix".
-
-**Right panel (60%):**
-- Three screenshot thumbnails: Front, Top, Isometric.
-- Click to expand to full size.
-- Render status badge (pending / rendering / success / error).
-- Render error message (if any), copyable.
-
-**History section (below):**
-- Table of all previous iterations for this category.
-- Columns: Iteration, Status, Approved, Render Status, Created at, View Code.
-
-### 10.4 Dataset Export Panel (in Admin tab or separate `/workbench/export`)
-
-- Stats: total approved examples, breakdown by tier.
-- "Export JSONL" button → downloads file.
-- "View Active System Prompt" → opens system prompt text in a read-only viewer.
-
----
-
-## 11. Training Dataset Format
-
-Each approved example becomes one training record in the fine-tuning dataset.
-
-### 11.1 JSONL Structure (LLaMA-Factory conversation format)
+One record per approved example:
 
 ```json
 {
@@ -583,7 +596,7 @@ Each approved example becomes one training record in the fine-tuning dataset.
     },
     {
       "from": "human",
-      "value": "{category description + any additional context}"
+      "value": "{example prompt — the user-facing natural language description}"
     },
     {
       "from": "gpt",
@@ -593,78 +606,105 @@ Each approved example becomes one training record in the fine-tuning dataset.
 }
 ```
 
-One JSON object per line. File: `workbench-dataset-{timestamp}.jsonl`.
+### 12.2 Scale Targets
 
-### 11.2 Example Count Targets
+| Phase | Prompts | Runs/prompt | Target examples |
+|-------|---------|-------------|----------------|
+| v1 | 1,100 | 1 | ~900–1,000 (accounting for rejects) |
+| v2 | 1,100 | 5 | ~4,500–5,000 |
+| Final | 1,100 | 10 | ~9,000–10,000 |
 
-| Tier | Categories | Target examples/category | Target total |
-|------|-----------|--------------------------|--------------|
-| 0 | 8 | 3 | 24 |
-| 1 | 10 | 3 | 30 |
-| 2 | 10 | 2 | 20 |
-| 3 | 10 | 2 | 20 |
-| 4 | 8 | 2 | 16 |
-| 5 | 4 | 2 | 8 |
-| **Total** | **50** | | **~118** |
-
-A dataset of ~100–150 high-quality, validated examples is the minimum viable fine-tuning set. Quality over quantity: one well-validated example is worth 10 generated-but-unchecked examples.
+Additional runs use varied temperature (0.7–1.2) and different random seeds to get stylistic variation in the generated code (different but equally valid approaches to the same object).
 
 ---
 
-## 12. Implementation Phases
+## 13. Frontend Design
 
-### Phase 1 — Screenshot Service (current)
+### 13.1 Routes
 
-- [ ] Create `services/screenshot-service/` directory
-- [ ] Node.js + Express app with Puppeteer + Three.js HTML template
-- [ ] `POST /screenshot` endpoint accepting STL base64
-- [ ] `GET /health` endpoint
-- [ ] Dockerfile
-- [ ] Add to `docker-compose.yml`
-- [ ] Add `SCREENSHOT_SERVICE_URL` env var and config entry
-- [ ] Verify build succeeds
+| Path | Component | Description |
+|------|-----------|-------------|
+| `/workbench` | `WorkbenchPage` | Category overview + stats |
+| `/workbench/:categoryId` | `WorkbenchCategoryPage` | Prompt list + generation controls |
+| `/workbench/:categoryId/:promptId` | `WorkbenchPromptPage` | Example attempts, screenshots, eval scores |
 
-### Phase 2 — Backend Workbench API
+All guarded by `AdminRouteGuard`. Navigation entry added to admin nav group.
 
-- [ ] DB migration: `workbench_categories`, `workbench_examples`, `workbench_system_prompts`
-- [ ] Write comprehensive `build123d-system-prompt.md` asset
-- [ ] Seed script for 50 categories
-- [ ] `workbench.service.ts` (generation pipeline logic)
+### 13.2 Workbench Page
+
+- Stats bar: total auto_approved / human_approved / pending / flagged
+- Category cards: progress bar (approved / total prompts), complexity badge
+- "Seed from files" button, "Export JSONL" button
+
+### 13.3 Category Page
+
+- Prompt list (100 rows): index, truncated prompt text, best eval score, approval status
+- Filter: all / pending / approved / flagged
+- "Run batch" button to queue all pending prompts for automated generation
+
+### 13.4 Prompt Page
+
+- Full prompt text at top
+- Current best example: code + three screenshots + eval score + issues
+- "Retry" button (re-runs the pipeline)
+- "Edit code" + "Re-evaluate" for manual intervention
+- History: accordion list of all previous attempts
+
+---
+
+## 14. Implementation Phases
+
+### Phase 1 — Screenshot Service
+
+- [ ] `services/screenshot-service/` — Node.js + Express + Puppeteer + Three.js template
+- [ ] `POST /screenshot` and `GET /health` endpoints
+- [ ] Dockerfile + `docker-compose.yml` addition
+- [ ] `SCREENSHOT_SERVICE_URL` env var in backend config
+- [ ] Build verification
+
+### Phase 2 — Curriculum Content
+
+- [ ] Write `workbench/system-prompt.md` (comprehensive Build123d reference)
+- [ ] Write all 11 category files (`workbench/categories/01-primitives.md` … `11-pcb-cases.md`) with 100 prompts each
+- [ ] Seeder script validates file format and reports prompt count per category
+
+### Phase 3 — Backend API
+
+- [ ] DB migration: 4 new tables
+- [ ] `workbench.service.ts` — generation pipeline, VLM evaluation, fix loop
+- [ ] `visual-eval.service.ts` — adapted from `chat3d-docker`, Vercel AI SDK, multi-provider
 - [ ] `workbench.routes.ts` under `/api/admin/workbench`
-- [ ] Screenshot proxy via screenshot service
-- [ ] Dataset export endpoint (JSONL)
-- [ ] Verify backend builds
+- [ ] Screenshot service proxy
+- [ ] JSONL export
+- [ ] Build verification
 
-### Phase 3 — Frontend Workbench UI
+### Phase 4 — Frontend UI
 
-- [ ] `WorkbenchPage` component (category list + stats)
-- [ ] `WorkbenchCategoryPage` component (editor + screenshots + history)
-- [ ] Add `/workbench` route to `app.tsx` (admin-guarded)
-- [ ] Add "Workbench" to admin nav group
-- [ ] Frontend API client: `workbench.api.ts`
-- [ ] Verify frontend builds
+- [ ] `WorkbenchPage`, `WorkbenchCategoryPage`, `WorkbenchPromptPage`
+- [ ] Admin nav entry, route wiring
+- [ ] `workbench.api.ts` frontend client
+- [ ] Build verification
 
-### Phase 4 — Polish & Dataset Pipeline
+### Phase 5 — Batch Automation & Polish
 
+- [ ] Batch job queue with progress polling
+- [ ] Multiple seeds / re-run for dataset expansion
 - [ ] System prompt editor in UI
-- [ ] Multiple examples per category (rerun for additional variety)
-- [ ] Batch generation mode (run through all `pending` categories automatically)
-- [ ] Export preview (show sample records before downloading)
-- [ ] JSONL format validation on export
+- [ ] Export preview before download
 
 ---
 
-## 13. Open Questions / Decisions Deferred
+## 15. Open Questions / Deferred Decisions
 
 | # | Question | Status |
 |---|----------|--------|
-| 1 | Fine-tuning framework (LLaMA-Factory vs Axolotl) | Deferred — decide when training begins |
-| 2 | Multiple approved examples per category or one best example? | Start with one; extend in Phase 4 |
-| 3 | Should the auto-fix loop stream tokens back to the UI? | Nice-to-have; Phase 3 polish |
-| 4 | Rate limiting on `/generate` endpoint? | Add in Phase 2 (reuse existing rate limit infra) |
-| 5 | Where to store generated STL/STEP files for workbench? | Under `/data/storage/workbench/{exampleId}/` |
-| 6 | System prompt versioning for A/B testing? | Phase 4 |
+| 1 | Fine-tuning framework (LLaMA-Factory vs Axolotl vs Unsloth) | Deferred |
+| 2 | VLM default: Anthropic `claude-sonnet-4-6` or OpenAI `gpt-4o`? | Anthropic preferred; configurable |
+| 3 | Reference image per prompt (for VLM comparison)? | Nice-to-have; Phase 5 |
+| 4 | Rate limiting on `/generate` batch endpoint? | Add in Phase 3 |
+| 5 | File storage path for workbench renders | `/data/storage/workbench/{exampleId}/` |
+| 6 | Batch job persistence (in-memory vs DB-backed queue)? | Start in-memory; upgrade if needed |
 
 ---
 
-*End of Design Document v0.1*
+*End of Design Document v0.2*

--- a/workbench/categories/01-primitives.md
+++ b/workbench/categories/01-primitives.md
@@ -1,0 +1,112 @@
+---
+rank: 1
+name: Primitives
+complexity: 1
+description: >
+  Basic 3D primitive shapes available directly in build123d — Box, Cylinder,
+  Sphere, Cone, Torus, and Wedge. No sketches or operations required.
+  These are the foundational building blocks of all 3D models.
+---
+
+## Examples
+
+1. A solid cube paperweight with 60mm sides.
+2. A rectangular block of wood, 120mm long, 40mm wide, and 20mm tall.
+3. A thin flat plate, 200mm × 150mm and 3mm thick.
+4. A thick square slab, 80mm × 80mm and 25mm tall.
+5. A long narrow bar, 200mm long, 10mm wide, and 10mm tall.
+6. A short stubby brick, 50mm × 40mm × 30mm.
+7. A very flat disc-like slab, 100mm × 100mm and 2mm thick.
+8. A tall narrow tower block, 20mm × 20mm and 120mm tall.
+9. A solid cylinder 30mm in radius and 60mm tall.
+10. A thin rod or dowel pin, 5mm diameter and 80mm long.
+11. A chunky peg, 15mm diameter and 35mm tall.
+12. A wide flat disc, 90mm diameter and 6mm thick.
+13. A coin-like cylinder, 25mm diameter and 3mm thick.
+14. A large drum shape, 70mm diameter and 50mm tall.
+15. A slender post, 8mm diameter and 150mm tall.
+16. A solid sphere the size of a golf ball, approximately 43mm in diameter.
+17. A small marble, 16mm in diameter.
+18. A large decorative ball, 100mm in diameter.
+19. A bead for a necklace, 10mm in diameter.
+20. A ball bearing, 6mm in diameter.
+21. A pointed cone, 40mm base diameter and 60mm tall.
+22. A wide shallow cone, 80mm base diameter and 30mm tall.
+23. A truncated cone (frustum) used as a chess pawn base — 36mm bottom diameter, 22mm top diameter, 14mm tall.
+24. A funnel-shaped cone without the spout — 60mm base diameter, 20mm top diameter, 40mm tall.
+25. A narrow spike cone, 15mm base diameter and 80mm tall.
+26. A doughnut-shaped torus, 60mm major radius and 10mm minor radius.
+27. A thick ring like a rubber gasket, 40mm major radius and 8mm minor radius.
+28. A thin delicate ring, 50mm major radius and 3mm minor radius.
+29. A tubular torus with a large tube cross-section, 30mm major radius and 15mm minor radius.
+30. A small O-ring, 12mm major radius and 2mm minor radius.
+31. A box with a notch cut from one corner — a rectangular block 80mm × 60mm × 40mm where a 20mm cube is removed from one top corner. (Use two positioned Box primitives with mode subtract.)
+32. A pedestal — a wide base box topped by a narrower box. Base: 100mm × 100mm × 20mm. Top: 50mm × 50mm × 60mm.
+33. Three stacked cylinders forming a tiered cake shape. Bottom: 80mm diameter, 20mm tall. Middle: 55mm diameter, 20mm tall. Top: 30mm diameter, 20mm tall.
+34. A cylinder sitting on top of a box. Box: 60mm × 60mm × 30mm. Cylinder: 20mm diameter, 40mm tall, centred on the box.
+35. A sphere resting on a cylinder plinth. Plinth: 30mm diameter, 20mm tall. Sphere: 25mm diameter, resting on top.
+36. Two cylinders side by side, touching — each 20mm diameter and 50mm tall, placed 20mm apart on the X axis.
+37. A row of four cubes, each 20mm × 20mm × 20mm, placed 30mm apart along the X axis.
+38. A half-cylinder (semi-circular cross-section): 50mm diameter, 80mm long, sliced in half along its length using arc_size=180.
+39. A quarter-sphere dome, 60mm radius, cut to a quarter using arc_size parameters.
+40. A partial torus arc covering 180 degrees — like a curved tube handle, 50mm major radius and 8mm minor radius.
+41. A hockey-puck cylinder, 76mm diameter and 25mm tall.
+42. A spool or bobbin shape: two wide flanges (70mm diameter, 8mm thick) connected by a narrow centre hub (30mm diameter, 40mm tall), assembled from three cylinders.
+43. A lollipop: a sphere 30mm in diameter on top of a thin cylinder rod 5mm diameter and 60mm tall.
+44. A button: a very flat cylinder 18mm diameter and 4mm thick.
+45. A wheel: a cylinder 60mm diameter and 15mm wide.
+46. A ball-shaped knob on a cylindrical stem — sphere 25mm diameter, stem 10mm diameter and 30mm tall.
+47. A cone-tipped cylinder: a cylinder 20mm diameter and 40mm tall with a cone (20mm base, 0mm top, 25mm tall) sitting directly on top, aligned.
+48. A box standing on four cylindrical legs — box 80mm × 60mm × 5mm, four legs each 8mm diameter and 40mm tall at the corners.
+49. A sphere with a cylindrical bore through its centre — sphere 50mm diameter, cylinder 15mm diameter subtracted through it.
+50. A flat rectangular base with a cylindrical boss rising from the centre — base 100mm × 80mm × 5mm, boss 20mm diameter and 30mm tall.
+51. A cube 40mm on each side.
+52. A rectangular box with golden ratio proportions, approximately 60mm × 37mm × 23mm.
+53. A very thin sheet of material, like a sheet of aluminium — 200mm × 100mm × 1mm.
+54. A solid cylinder the shape of a standard AA battery — 14mm diameter and 50mm tall.
+55. A thick coin — 26mm diameter and 5mm tall.
+56. A short fat cylinder like a puck — 50mm diameter and 15mm tall.
+57. A solid sphere 20mm in radius.
+58. A narrow cylinder like a pencil — 7mm diameter and 175mm long.
+59. A truncated cone like a plastic cup without the opening — 70mm top diameter, 55mm bottom diameter, 95mm tall.
+60. A flattened oblate spheroid approximated by a wide torus with very small minor radius — 80mm major radius and 5mm minor radius.
+61. A large sphere like a bowling ball — 108mm in diameter.
+62. A teardrop-like cone: 50mm base diameter and 120mm tall, very elongated.
+63. A tiny sphere like a ball bearing — 3mm in diameter.
+64. A cylinder the shape of a standard D-cell battery — 33mm diameter and 61mm tall.
+65. A flat box like a smartphone — 150mm × 75mm × 8mm.
+66. A tall thin box like a book — 200mm × 30mm × 280mm.
+67. A large torus like a lifesaver ring — 200mm major radius and 30mm minor radius.
+68. A box shaped like a standard house brick — 215mm × 102mm × 65mm.
+69. A half-sphere dome: sphere 80mm diameter, flat side down, using arc_size to keep only the top hemisphere.
+70. A cylinder with a very small arc: a 270-degree partial cylinder (three-quarter tube), 40mm diameter and 50mm tall.
+71. A solid rectangular bar like a steel flat bar — 200mm × 40mm × 10mm.
+72. A cube with a sphere subtracted from the top centre — 60mm cube with a 30mm radius sphere sunk into the top.
+73. A cylinder with a conical tip on both ends — cylinder 20mm diameter and 60mm, cone 20mm base and 20mm tall on each end.
+74. A thin ring like a finger ring — 20mm inner diameter, 22mm outer diameter, 6mm tall (small cylinder subtracted from larger).
+75. A set of three concentric rings (three tori with increasing major radii: 20mm, 35mm, 50mm), all with 3mm minor radius, in the same plane.
+76. A solid box with rounded edges that approximate a pillow shape — 80mm × 60mm × 20mm.
+77. A post with a spherical cap — cylinder 12mm diameter and 40mm tall, with a hemisphere 12mm radius on top.
+78. A disc with a raised circular rim — flat disc 80mm diameter and 5mm thick with a cylinder ring 70mm diameter and 8mm tall on top.
+79. A cone pointing downward like a funnel top — 60mm base at top, 0mm at bottom, 50mm tall, inverted.
+80. Two spheres of different sizes fused together — large sphere 40mm diameter and small sphere 25mm diameter, touching at their surfaces.
+81. A rectangular slab with four cylindrical holes at each corner — slab 100mm × 80mm × 10mm, holes 8mm diameter.
+82. A cylinder with a flat on one side — cylinder 30mm diameter and 50mm tall with a thin slab subtracted from one side.
+83. A rounded rectangle slab, approximated by a box 100mm × 60mm × 10mm with cylindrical cutouts at each corner to round them.
+84. A torus in a vertical orientation (standing upright) — 50mm major radius and 10mm minor radius, rotated 90 degrees from horizontal.
+85. A thick washer shape: outer cylinder 50mm diameter and 15mm tall with inner cylinder 30mm diameter subtracted.
+86. A hollow tube: outer cylinder 40mm diameter and 80mm tall with inner cylinder 34mm diameter subtracted.
+87. A sphere with two opposite cylindrical bores through it — sphere 60mm diameter with two 15mm diameter cylinders subtracted along perpendicular axes.
+88. A tall obelisk: a long box 20mm × 20mm × 150mm with a small pyramid-like cone on top.
+89. A barrel shape: cylinder 60mm diameter and 80mm tall. (Note: approximate barrel with a standard cylinder.)
+90. A stubby thumbtack: flat disc 20mm diameter and 3mm thick, with a sharp cone 4mm base and 15mm tall underneath its centre.
+91. A compact square post: 15mm × 15mm × 80mm tall.
+92. A flat oval approximated by an elliptically-proportioned box — 120mm × 60mm × 8mm.
+93. A simple plug: cylinder 25mm diameter and 20mm tall.
+94. A dome over a cylinder base: cylinder 50mm diameter and 30mm tall with a hemisphere 50mm diameter on top.
+95. A tapered rectangular block (like a doorstop): full-size box 150mm × 60mm × 40mm.
+96. A small cube earring, 8mm on each side.
+97. A large cube like a decorative concrete block, 300mm on each side.
+98. A flat square tile, 100mm × 100mm × 4mm.
+99. A thick hexagonal prism approximated by a Box primitive: use a Box 60mm × 52mm × 20mm as a stand-in for a hexagonal rod.
+100. A multi-tier wedding cake silhouette: four stacked cylinders with decreasing diameters — 120mm/20mm, 90mm/25mm, 60mm/25mm, 40mm/20mm.

--- a/workbench/categories/02-sketch-operations.md
+++ b/workbench/categories/02-sketch-operations.md
@@ -1,0 +1,112 @@
+---
+rank: 2
+name: Sketch Operations
+complexity: 2
+description: >
+  2D sketch-based profiles using BuildSketch and BuildLine contexts.
+  Examples cover closed profiles (make_face), open wires, and common
+  2D shapes that serve as the foundation for extrusion and revolution.
+---
+
+## Examples
+
+1. A flat L-shaped cross-section profile, arms 80mm and 60mm long, both 15mm wide, 4mm thick.
+2. A T-shaped flat bracket profile, 100mm wide across the top, 60mm tall stem, all 12mm thick.
+3. A C-channel profile: 80mm tall, 40mm wide flanges, 6mm wall thickness.
+4. A U-channel profile: 60mm wide opening, 40mm deep, 5mm wall thickness.
+5. A Z-shaped flat profile, each arm 40mm long and 12mm wide.
+6. A plus-sign shaped flat profile, four arms each 30mm long and 12mm wide.
+7. An I-beam cross-section profile, 80mm tall, 60mm wide flanges, 8mm web thickness, 12mm flange thickness.
+8. A flat rectangular frame (hollow rectangle): outer 100mm × 80mm, wall 8mm thick, 4mm deep.
+9. A flat circular ring sketch: outer circle 60mm diameter, inner circle 40mm diameter.
+10. An equilateral triangle sketch, 80mm side length, extruded 5mm thick.
+11. A regular hexagon sketch, 50mm across flats.
+12. A regular octagon sketch, 60mm across flats.
+13. A five-pointed star sketch with 50mm outer radius and 25mm inner radius.
+14. A six-pointed star (Star of David) sketch, outer radius 50mm, inner radius 25mm.
+15. A flat crescent sketch: two overlapping circles of different sizes and positions forming a crescent.
+16. An ellipse sketch, 80mm wide and 50mm tall.
+17. A rounded rectangle sketch, 100mm × 60mm with 15mm corner radii.
+18. A keyhole profile sketch: rectangle 30mm × 80mm with a semicircle 30mm diameter on top.
+19. An arrow head profile sketch pointing upward: equilateral triangle with a rectangular tail.
+20. A flat cross (Greek cross) profile, equal arms 20mm wide and 60mm long.
+21. A D-shape sketch: semicircle 50mm radius joined to a 100mm flat edge.
+22. A flat washer sketch: filled annulus 80mm outer diameter, 50mm inner diameter.
+23. A trapezoidal profile: bottom edge 100mm, top edge 60mm, height 50mm.
+24. A parallelogram profile: 100mm base, 60mm tall, 20mm lean to the right.
+25. A sketch of a rounded square: 60mm × 60mm with 10mm corner radii.
+26. A slot profile: two semicircles at each end of a rectangle, total length 80mm, width 20mm.
+27. A teardrop profile: circle 30mm diameter blended into a pointed tip, total height 60mm.
+28. A flat fan or sector sketch: quarter-circle wedge, 60mm radius.
+29. A sketch of a fish shape: two intersecting circular arcs forming a lens with a pointed tail.
+30. A flat chevron (single V-shape) profile, arm length 40mm, width 10mm, angle 120 degrees.
+31. A flat kidney-bean outline sketch, approximately 80mm × 50mm.
+32. A concave lens sketch: two circular arcs bowing away from each other.
+33. A convex lens (vesica piscis) sketch: two circular arcs bowing toward each other.
+34. A flat dumbbell outline: two circles 30mm diameter connected by a 10mm wide neck 40mm long.
+35. A rectangle with a triangular notch cut from one side: 80mm × 60mm with a 20mm-wide V notch in the middle of one long side.
+36. A flat spanner head profile: circle with two parallel flats, 40mm diameter, 30mm across flats.
+37. A flat tablet-shaped profile (stadium shape): 80mm long, 30mm wide, fully rounded ends.
+38. A gear-tooth arc sketch: a small arc with a radial tooth projection, approximating a single gear tooth in 2D.
+39. A flat heart outline sketch.
+40. An arrowhead outline: a right-pointing triangle-based arrow shape, 80mm long and 50mm wide.
+41. A flat boomerang profile: two straight arms at 120 degrees, each 60mm long and 12mm wide.
+42. A flat horseshoe sketch: semicircular arc with two parallel legs, 60mm outer radius, 10mm thick.
+43. A propeller blade cross-section sketch: elongated oval, 100mm × 20mm with slight asymmetry.
+44. A flat rectangular cross section with a semicircular bite taken from one edge — 80mm × 40mm with a 20mm-radius semicircle removed from the middle of one long side.
+45. A pointed ellipse (vesica piscis): two arcs forming a pointed oval, 80mm tall and 40mm wide.
+46. A flat bracket profile: large rectangle with a rectangular cutout, like a picture frame missing one side.
+47. A flat pentagon sketch, 70mm across flats.
+48. A flat heptagon (7-sided) sketch, 60mm across flats.
+49. A flat decagon (10-sided) sketch, 50mm across flats.
+50. A sketch for a picture frame: outer rectangle 200mm × 150mm, inner rectangle 160mm × 110mm, creating a frame border.
+51. A flat oval racetrack sketch (stadium): 140mm long, 60mm wide.
+52. A flat ring with four radial spokes: outer ring 80mm diameter, inner hub 20mm diameter, four spokes 8mm wide.
+53. A flat cross-shaped mounting plate: 100mm × 100mm cross with arms 30mm wide.
+54. A sketch of an isosceles triangle: 80mm base, 100mm tall.
+55. A sketch of a right-angle triangle: 60mm base, 80mm tall.
+56. An annular sector sketch: a pie-slice ring, outer radius 60mm, inner radius 35mm, angle 90 degrees.
+57. A flat comb profile: rectangular base 80mm × 10mm with five rectangular teeth 8mm wide and 20mm tall rising from it.
+58. A circular sector sketch (pizza slice): radius 60mm, angle 60 degrees.
+59. A rounded-corner triangle: equilateral triangle 80mm sides with 10mm corner radii.
+60. A flat S-curve profile sketch using two arcs: creating an S-shaped thick band 10mm wide.
+61. A thin-walled round tube cross-section: circle 40mm outer, circle 36mm inner (annulus).
+62. A flat rectangular plate with a circular hole centred in it: plate 100mm × 80mm, hole 30mm diameter.
+63. A flat triangular plate with a circular hole: equilateral triangle 100mm sides with a 20mm-diameter hole at the centroid.
+64. A flat rectangular plate with a slot down the middle: plate 100mm × 60mm, slot 10mm wide and 60mm long, centred.
+65. A flat figure-eight sketch: two circles 30mm diameter, tangent to each other.
+66. A flat sketch of a rounded L-shape: all corners rounded to 10mm radius, arms 80mm and 60mm, width 15mm.
+67. A flat hexagonal ring: outer hexagon 60mm across flats, inner hexagon 40mm across flats.
+68. A flat propeller silhouette: three identical elliptical blades 80mm × 20mm arranged 120 degrees apart around a 20mm centre circle.
+69. A flat dovetail profile: trapezoid wider at top, 30mm top, 50mm bottom, 20mm tall.
+70. A flat T-slot cross-section: a T-shape where the crossbar is wider than the stem and partially recessed, used in extrusion profiles.
+71. A flat sketch of a bracket with two mounting holes: 80mm × 40mm rectangle with two 8mm holes, 10mm from each end.
+72. A flat semi-annular (half-ring) sketch: outer radius 50mm, inner radius 30mm, covering 180 degrees.
+73. A flat diamond (rhombus) sketch: 80mm wide and 60mm tall.
+74. A flat staircase profile: three steps, each 20mm wide and 20mm tall, forming a right-angled staircase in cross-section.
+75. A flat asymmetric bracket: one arm 60mm long and 15mm wide, other arm 40mm long and 15mm wide, joined at 90 degrees.
+76. A flat ring with six equally spaced holes: outer ring 80mm diameter, inner hub 20mm, six holes 8mm diameter.
+77. A flat sketch of a USB-A port opening: 14mm wide and 6mm tall, with chamfered top corners.
+78. A flat parabolic arch outline: a smooth parabolic curve spanning 100mm wide and 60mm tall.
+79. A flat sketch of two concentric hexagons: outer 80mm across flats, inner 50mm across flats.
+80. A flat irregular quadrilateral (trapezoid with unequal sides): base 100mm, top 60mm offset to one side, 50mm tall.
+81. A flat elongated hexagon (like an extended bolt head): 30mm across flats, 60mm long.
+82. A flat circular pattern of six small circles (like a flower): centre circle 15mm diameter surrounded by six circles 10mm diameter at 30mm from centre.
+83. A flat rectangular frame with diagonal bracing in one corner: outer 120mm × 80mm, frame 10mm wide, one diagonal brace.
+84. A flat gear-like profile: circle 60mm diameter with 12 rectangular teeth 5mm wide and 8mm tall arranged around the circumference.
+85. A flat serpentine or wave profile: sinusoidal edge on one side of a 10mm-thick band, spanning 100mm.
+86. A flat sketch of a coin slot: 30mm wide and 2.5mm tall, with sharp corners.
+87. A flat hexagonal plate with a hexagonal cutout: outer 100mm across flats, inner cutout 60mm across flats.
+88. A flat cross-section of an I-beam (structural steel): 100mm wide flanges, 150mm total height, 8mm web thickness, 14mm flange thickness.
+89. A flat sketch of a thumbscrew head: circle 30mm diameter with three radial grip slots 2mm wide and 10mm long.
+90. A flat compound profile: a rectangle 60mm × 40mm with a semicircle on one end and a triangle on the other end.
+91. A flat sketch of a spring cross-section: circle 8mm diameter (the wire profile).
+92. A flat rounded equilateral triangle: 80mm sides, 15mm corner radii.
+93. A flat track profile for a slot car: U-channel 50mm wide and 10mm deep with 3mm wall thickness.
+94. A flat sketch of a standard M8 bolt head: hexagon 13mm across flats.
+95. A flat sketch of a decorative scalloped edge: a rectangle 80mm × 20mm with a wavy (scalloped) bottom edge.
+96. A flat sketch of a spline curve: smooth freeform curve forming a closed S-shaped boundary.
+97. A flat sketch of a reuleaux triangle: a curved triangle with each side being a circular arc, 80mm across.
+98. A flat multi-layer star: outer 10-point star 80mm outer radius, 40mm inner radius; inner 10-point star 35mm outer radius, 20mm inner radius.
+99. A flat profile for a picture hook: rectangular top 30mm × 10mm with a curved hook extending 15mm down.
+100. A flat circular sketch with a keyway: circle 50mm diameter with a rectangular slot 8mm wide and 5mm deep cut from one side, used as a shaft cross-section.

--- a/workbench/categories/03-extrusions-revolutions.md
+++ b/workbench/categories/03-extrusions-revolutions.md
@@ -1,0 +1,112 @@
+---
+rank: 3
+name: Extrusions and Revolutions
+complexity: 3
+description: >
+  Transforming 2D profiles into 3D solids using extrude and revolve operations.
+  Includes straight extrusions, tapered extrusions, and revolved solids of revolution
+  such as vases, bowls, cups, and rings.
+---
+
+## Examples
+
+1. An L-shaped bracket extruded 5mm thick from an L-profile — arms 80mm and 60mm, both 12mm wide.
+2. A T-slot extrusion 100mm long — standard T-shape cross-section with the crossbar 30mm wide, stem 10mm wide and 20mm tall.
+3. A U-channel rail 150mm long, 40mm wide, 30mm deep, 4mm wall thickness.
+4. A simple bookend: an L-profile extruded 80mm — vertical arm 120mm tall and 5mm thick, horizontal foot 80mm wide and 5mm thick.
+5. An I-beam 200mm long — 60mm wide flanges, 100mm total height, 6mm web, 10mm flange thickness.
+6. A picture frame moulding profile extruded 400mm — outer 30mm × 25mm, flat back, decorative front profile.
+7. A door stop: a right-triangle cross-section extruded 80mm — base 60mm, height 30mm, wedge shape.
+8. A guttering channel: U-profile extruded 300mm — 80mm wide, 60mm deep, 3mm thick.
+9. A cable duct: rectangular channel 40mm × 30mm extruded 200mm, 3mm wall thickness.
+10. A hex bar stock: regular hexagon 27mm across flats, extruded 100mm.
+11. A star-shaped pillar: 6-pointed star profile extruded 60mm tall, outer radius 50mm, inner radius 25mm.
+12. A cross-shaped column: plus-sign cross-section extruded 120mm — each arm 20mm wide and 60mm long.
+13. A triangular wedge: equilateral triangle profile extruded 100mm.
+14. A tapered extrusion: rectangular base profile 60mm × 40mm extruded 80mm with a 10-degree outward taper on the sides.
+15. A flower pot shape: circular profile extruded 120mm with a 5-degree inward taper from bottom to top.
+16. A pointed cone via tapered extrusion: circle 60mm diameter extruded 80mm with full taper to a point.
+17. A truncated pyramid: 100mm × 80mm rectangle at base extruded 60mm with 15-degree taper.
+18. A diamond ring: circular cross-section profile revolved 360 degrees around a vertical axis — ring diameter 22mm, wire 2mm diameter.
+19. A ceramic bowl: half-moon profile revolved — outer radius 80mm, inner radius 73mm at rim, 10mm flat bottom.
+20. A wine glass body (without stem): wide parabolic cup profile revolved 360 degrees — 70mm diameter rim, 100mm tall.
+21. A turned wooden vase: S-curve profile revolved — 60mm max diameter, 150mm tall with a graceful waist.
+22. A salad bowl: shallow concave profile revolved — 200mm diameter, 80mm deep.
+23. A shot glass: straight-sided cylinder with slight taper — 45mm top diameter, 40mm bottom, 55mm tall, walls 3mm thick. Revolved.
+24. A round knob for a drawer: mushroom profile revolved — 35mm diameter cap, 10mm stem, 20mm total height.
+25. A pulley groove: revolved profile creating a V-groove wheel, 80mm outer diameter, 15mm groove depth.
+26. A spinning top: cone profile revolved — 60mm base diameter tapering to a sharp tip, 80mm tall.
+27. A ring toss ring: circular torus-like shape, major radius 80mm, minor radius 8mm. Use revolve.
+28. A trumpet bell: flared profile revolved — narrow end 20mm diameter, flared end 80mm diameter, 80mm along the axis.
+29. A dome lid for a dish: hemispherical profile revolved — 120mm diameter, 3mm thick wall, open bottom.
+30. A candleholder cup: short wide cylinder profile revolved — 60mm outer diameter, 50mm inner diameter, 40mm tall.
+31. A cork for a bottle: slightly tapered cylinder revolved — 20mm top diameter, 18mm bottom diameter, 30mm tall.
+32. A wheel hub: disc with central bore revolved — 100mm outer diameter, 20mm bore, 30mm wide.
+33. A hollow sphere via revolve: semicircle profile revolved 360 degrees — 50mm radius, 3mm wall thickness.
+34. A chess rook castle top: notched cylinder profile revolved — 40mm outer diameter, 50mm tall, with battlements represented as step cuts in the top profile.
+35. A baseball bat barrel: tapered cylinder profile revolved — 70mm max diameter, 60mm narrow end, 300mm long.
+36. A trumpet mouthpiece: complex profile revolved — funnel shape 20mm wide rim, 12mm bore, 60mm long.
+37. A donut (torus) via revolve: circular 10mm wire cross-section revolved around a 60mm radius circle.
+38. A lathe-turned handle: complex profile with gripping grooves revolved — 30mm max diameter, 120mm long.
+39. A mushroom cap: wide flat dome profile revolved — 80mm diameter, 30mm tall, slightly concave underneath.
+40. A funnel: wide-to-narrow cone profile revolved — 100mm top diameter, 20mm spout, 80mm tall, 3mm wall.
+41. A flower vase with a narrow neck: bulging body narrowing to a neck, revolved — 80mm max diameter, 30mm neck, 200mm tall.
+42. A tapered cup: profile revolved — 75mm top diameter, 55mm bottom diameter, 90mm tall, 2mm wall.
+43. A spool for thread: two flanges connected by a narrow core, revolved — flanges 60mm diameter, core 20mm, 80mm total width.
+44. A spinning gyroscope ring: flat disc with rounded edges revolved — 80mm outer diameter, 60mm inner diameter, 15mm thick.
+45. A decorative vase with a flared foot and narrow neck: complex S-curve profile revolved — 120mm max diameter, 200mm tall.
+46. An O-ring: small circular cross-section revolved — major radius 20mm, minor radius 2mm.
+47. A lens shape: convex profile revolved — 60mm diameter, 10mm centre thickness, tapering to sharp edges.
+48. A bowl with a pedestal foot: wide shallow bowl joined at the bottom to a narrow foot, revolved — 180mm bowl diameter, 50mm foot height.
+49. A simple ring (wedding band): rectangular cross-section revolved — 21mm inner diameter, 3mm wide, 2mm tall.
+50. A gear blank: flat disc with a central boss, revolved — 100mm outer diameter, 20mm centre boss, 15mm tooth height region.
+51. A cooking pot body: straight-sided cylinder with rounded bottom profile revolved — 160mm diameter, 120mm tall, 3mm walls.
+52. A birdbath basin: wide shallow dish revolved — 300mm diameter, 80mm deep, rounded edges.
+53. A bottle neck and shoulder: complex profile revolved — 25mm neck diameter, 80mm body diameter, 30mm shoulder transition.
+54. A round soap dish: oval (half-cylinder) tray profile revolved around its long axis — 120mm long, 40mm wide, 20mm deep.
+55. A pipe elbow profile revolved 90 degrees: circular tube cross-section revolved to form a 90-degree bend — 25mm bore, 5mm wall.
+56. A bullet shape: cylinder-and-ogive profile revolved — 9mm diameter, 16mm long.
+57. A chess bishop hat: pointed dome profile revolved — 30mm base diameter, 60mm tall with a pointed top.
+58. A chess queen crown: profile revolved creating a crown shape — 40mm diameter, 60mm tall with serrations.
+59. A rounded pebble shape: smooth ovoid profile revolved — 60mm wide, 40mm tall.
+60. A cylindrical jar: straight cylinder with flat bottom, revolved — 80mm outer diameter, 100mm tall, 2mm wall, open top.
+61. A wok shape: deep rounded bowl profile revolved — 320mm top diameter, 80mm base diameter, 120mm deep.
+62. A soap bar mould shape: extruded rounded-rectangle profile — 90mm × 55mm × 30mm with 8mm corner rounding.
+63. A round table top: flat disc 900mm diameter and 20mm thick, extruded.
+64. A chair leg: tapered cylinder extruded — 40mm top diameter, 30mm bottom diameter, 440mm tall. (Tapered extrusion.)
+65. A surfboard fin: asymmetric teardrop profile extruded 3mm then tapered toward the tip.
+66. An aerofoil section extruded 100mm: NACA-like profile approximately 80mm chord, 12mm max thickness.
+67. A skirting board moulding: decorative L-profile with a cove, extruded 1000mm.
+68. A kayak paddle blade: wide teardrop profile extruded 8mm — 200mm × 90mm blade.
+69. A Gothic arch opening: pointed arch profile extruded 200mm — 100mm wide, 160mm tall arch, 10mm wall.
+70. A knife blade cross-section: asymmetric wedge profile extruded 180mm — 25mm wide, tapering to a sharp edge.
+71. A ski jump profile extruded 50mm: concave curve transitioning to upward-angled ramp, total length 300mm.
+72. A skateboard ramp quarter-pipe: quarter-circle profile extruded 400mm wide — 1000mm radius, 1500mm tall.
+73. A spiral staircase tread: pie-slice wedge profile extruded 20mm thick — 1200mm outer radius, 300mm inner radius, 15-degree sector.
+74. A banana-shaped extrusion: curved crescent profile extruded 30mm thick.
+75. A guitar body outline extruded 45mm: classic double-cutaway body shape roughly 380mm × 320mm.
+76. A snowboard profile: extruded board shape 160mm long (scaled), 25mm wide, 8mm thick with tip and tail upturn.
+77. A surfboard rail cross-section extruded 600mm: teardrop-like profile 20mm thick and 600mm long.
+78. A train rail cross-section extruded 200mm: standard rail profile with head, web, and flange.
+79. A horseshoe arch profile extruded 300mm: horseshoe-shaped opening with thick walls.
+80. A dragon-tail profile extruded 20mm: thick S-curve forming a decorative bracket-like shape.
+81. A crown moulding cross-section profile extruded 500mm: classic cove-and-bead decorative profile.
+82. A saucepan lip profile revolved: the rim of a saucepan — 160mm diameter, rolled-over edge cross-section, revolved 360 degrees.
+83. A half-pipe swimming pool end wall: semicircular profile extruded 500mm wide.
+84. A suspension bridge cable cross-section: circle of circles — 19 strands of 5mm wire bundled, each revolved individually and arranged in a hexagonal close-pack. (Approximate with a single 30mm circle bundle extrusion.)
+85. A bath plug with chain hole: flat disc 60mm diameter and 8mm thick extruded, with a small cylinder 4mm diameter subtracted for the chain hole.
+86. An extruded text profile (letter A): approximate A-shape extruded 10mm thick.
+87. A hex socket head: a hexagonal blind hole profile — round outer cylinder 20mm diameter, hexagonal bore 12mm across flats, 10mm deep.
+88. A gear rack: flat bar 100mm × 15mm × 10mm with a row of right-angle teeth on top — 10 teeth, each 4mm wide and 3mm tall.
+89. A crown gear tooth profile extruded: one tooth of a crown gear, trapezoidal cross-section 6mm × 4mm, extruded 12mm radially.
+90. A prismatic beam with a web opening: I-beam profile 200mm long with a circular lightening hole 40mm diameter in the centre of the web.
+91. A tapered pyramid from square base: 80mm × 80mm bottom, extruded 60mm tapering to zero — all four sides taper equally.
+92. A gothic spire: octagonal base extruded 200mm tapering to a point.
+93. A Roman column shaft: circle extruded 400mm with slight entasis (taper) — 50mm at base, 45mm at top.
+94. A vase with a pedestal base: bottom cylinder 60mm × 20mm, then an extruded or revolved waisted vase body, 80mm max diameter, 200mm tall.
+95. A candle flame holder: tall tapered cone revolved — 20mm wide at base, tapering to a point at 120mm tall.
+96. A test tube shape: cylinder revolved with closed hemispherical bottom — 20mm inner diameter, 3mm wall, 150mm tall including the rounded bottom.
+97. A toroidal speaker cone: shallow conical surface revolved — 120mm outer diameter, 30mm inner voice coil diameter, 25mm deep cone.
+98. A camera lens barrel section: cylinder revolved — 80mm outer diameter, 70mm inner diameter, 50mm long.
+99. A spinning gyroscope top: wide flat disc revolved with a pointed tip at the bottom — 80mm disc diameter, 5mm thick, pointed conical tip 40mm long.
+100. A turned table leg: complex profile revolved — alternating bulges and narrowings from 60mm at top to 30mm at foot over 700mm height, classic furniture leg shape.

--- a/workbench/categories/04-boolean-operations.md
+++ b/workbench/categories/04-boolean-operations.md
@@ -1,0 +1,112 @@
+---
+rank: 4
+name: Boolean Operations
+complexity: 4
+description: >
+  Combining, subtracting, and intersecting solids using Boolean operations.
+  Examples include fused composite shapes, drilled holes, slot cuts, pocket
+  machining operations, and shapes defined by intersection of two volumes.
+---
+
+## Examples
+
+1. A rectangular block 80mm × 60mm × 20mm with a single cylindrical through-hole 15mm diameter through its centre.
+2. A cube 60mm on each side with four cylindrical through-holes 8mm diameter, one near each corner, 10mm from each edge.
+3. A flat plate 120mm × 80mm × 10mm with a row of five 10mm diameter through-holes spaced evenly along the centreline.
+4. A hollow cube: a 60mm solid cube with a 50mm cube subtracted from the centre, leaving 5mm walls.
+5. A rectangular block 100mm × 60mm × 30mm with a rectangular slot 20mm wide and 15mm deep cut along the full length of the top.
+6. A block 80mm × 80mm × 40mm with a T-slot cut into the top surface — slot 10mm wide and 15mm deep, undercut 20mm wide and 5mm deep.
+7. A block with a blind pocket: 100mm × 80mm × 30mm block with a 60mm × 40mm rectangular pocket 15mm deep in the top face.
+8. A cylinder 60mm diameter and 80mm tall with a flat cut (a slab subtracted) removing one quarter of the cylinder lengthwise.
+9. A sphere 80mm diameter with a flat base — sphere with a box subtracted from the bottom so it sits flat.
+10. A cylinder 50mm diameter and 60mm tall with three evenly spaced 8mm through-holes drilled radially through the side wall.
+11. A box 100mm × 80mm × 50mm with two overlapping cylindrical holes 25mm diameter drilled from opposite ends, meeting in the middle.
+12. A rounded cylinder 40mm diameter and 100mm tall with a longitudinal slot 8mm wide and 10mm deep cut along the full length.
+13. A block 80mm × 40mm × 30mm with a dovetail slot cut into the top — trapezoidal cross-section 20mm wide at top, 28mm wide at base, 12mm deep.
+14. A thick disc 100mm diameter and 30mm thick with a hexagonal blind hole 20mm across flats and 20mm deep in the centre.
+15. A block with a countersunk hole: 60mm × 40mm × 20mm block, a 10mm through-hole widened to 18mm conical countersink at the top surface.
+16. A block with a counterbored hole: 60mm × 40mm × 20mm block, 10mm through-hole with an 18mm × 5mm deep counterbore on the top.
+17. A cylinder 80mm diameter and 50mm tall with a rectangular keyway slot 10mm wide and 5mm deep cut along the full length.
+18. A hollow cylinder (pipe section): 50mm outer diameter, 40mm inner diameter, 100mm long.
+19. A box 100mm × 100mm × 60mm with a large cylindrical pocket 70mm diameter and 50mm deep, leaving a 5mm ring wall and base.
+20. A flat bracket 120mm × 80mm × 8mm with two M6 mounting holes (6.5mm diameter) and one M8 pass-through hole (9mm diameter).
+21. Two cylinders of the same size fused together side by side into a figure-8 cross-section — each 30mm diameter and 60mm tall, centres 30mm apart.
+22. A sphere and cylinder fused: cylinder 30mm diameter and 50mm tall, topped by a sphere 35mm diameter merged at the top.
+23. A cross-shaped solid: two rectangular bars 100mm × 20mm × 20mm fused at right angles through the centre.
+24. A compound solid: a box 80mm × 60mm × 40mm with a smaller box 40mm × 40mm × 20mm fused on top and centred.
+25. A T-shaped 3D solid: vertical bar 20mm × 20mm × 80mm fused to a horizontal bar 80mm × 20mm × 20mm at the top.
+26. A plus-sign solid (3D cross): three rectangular bars 100mm × 15mm × 15mm fused at their centres along three orthogonal axes.
+27. A rectangular block with a cylindrical boss on top: block 80mm × 60mm × 20mm, boss 25mm diameter and 15mm tall, centred.
+28. A sphere 60mm diameter intersected with a cube 50mm × 50mm × 50mm — keep only the volume where both overlap.
+29. A cylinder 60mm diameter and 60mm tall intersected with a box 60mm × 60mm × 60mm — yields a rounded-corner box.
+30. Two overlapping spheres 50mm diameter, centres 30mm apart — keep only the lens-shaped intersection.
+31. A rounded box: a box 80mm × 60mm × 30mm with cylinders subtracted at each of the four vertical edges to round them.
+32. A lock-jaw shape: a cylinder with a rectangular cross-cut through the middle, creating a C-clamp profile — cylinder 60mm diameter and 40mm tall, slot 20mm × 40mm.
+33. A box with a chamfered edge: block 80mm × 50mm × 30mm with a 10mm × 10mm triangular prism subtracted from one long edge.
+34. A cylinder 40mm diameter and 60mm tall with a 10mm sphere subtracted from the top centre, leaving a hemispherical dimple.
+35. A flat plate 120mm × 80mm × 6mm with a series of lightening holes — eight 15mm diameter holes in a 2×4 grid.
+36. A pipe tee joint: three cylindrical tubes 25mm outer diameter and 3mm wall, fused at their ends forming a T-shape.
+37. A block with a cross-hole: 80mm × 40mm × 40mm block with two 15mm diameter through-holes drilled perpendicular to each other and intersecting in the middle.
+38. An L-bracket: two rectangular bars fused at right angles — each 80mm × 20mm × 5mm.
+39. A solid cylinder with a hexagonal through-hole — cylinder 50mm diameter and 40mm tall, hexagonal bore 17mm across flats all the way through.
+40. A flat washer made by Boolean subtraction: outer cylinder 50mm diameter and 5mm tall, inner cylinder 30mm diameter subtracted.
+41. A star-shaped cookie cutter: flat cylinder 80mm diameter and 40mm tall with a five-point star shape extruded and subtracted through the middle.
+42. A screw head socket: cylinder 15mm diameter with a Phillips-cross slot subtracted from the top — two rectangular slots 2mm wide and 8mm deep at 90 degrees.
+43. A block 80mm × 60mm × 40mm with a slot cut diagonally through it — a rectangular bar at 45 degrees subtracted.
+44. A rounded bracket: L-shaped bracket with a cylinder subtracted from the inner corner to create a clean radius.
+45. A mortise and tenon joint (one piece): a rectangular block 80mm × 40mm × 30mm with a rectangular slot (mortise) 20mm × 10mm × 20mm cut into one end.
+46. A box with cable pass-through holes: 100mm × 80mm × 60mm box, two 15mm diameter holes centred on opposite end faces.
+47. A hub with spokes: central cylinder 40mm diameter and 20mm tall, with four flat spoke bars 60mm × 8mm × 8mm fused at 90-degree intervals.
+48. A cylinder with an angled cut at the top — cylinder 40mm diameter and 80mm tall with a box subtracted at 30 degrees to create an angled opening (like a mitre cut).
+49. A tube with a saddle cut: cylinder 40mm outer diameter and 100mm tall, with a matching-diameter cylinder subtracted perpendicular through its side wall, leaving a fish-mouth opening.
+50. A rectangular channel with a rounded bottom: U-channel created by subtracting a semicylinder from a rectangular block.
+51. A block 80mm × 80mm × 40mm with a sphere 80mm diameter subtracted from the top, creating a hemispherical bowl recess.
+52. A cylinder 60mm diameter and 100mm tall with a helical-approximation slot subtracted: a rectangular bar twisted at 30 degrees subtracted from the side.
+53. A flat plate with a large D-shaped hole: 120mm × 100mm × 8mm plate, D-shape 60mm diameter subtracted from centre.
+54. A solid sphere 80mm diameter with a cylindrical tunnel 20mm diameter bored through the equator.
+55. A rectangular block with three different-sized cylindrical pockets on the top: small (10mm dia, 8mm deep), medium (20mm dia, 12mm deep), large (30mm dia, 16mm deep), evenly spaced.
+56. A hollow hemisphere (bowl shape) via Boolean subtraction: solid hemisphere 100mm radius minus a smaller solid hemisphere 94mm radius.
+57. A block with a wedge-shaped pocket: 100mm × 60mm × 40mm block with a triangular-cross-section slot cut along the top.
+58. A shaft with two flat key surfaces (double-D or dog-bone profile): cylinder 30mm diameter with two parallel flat slabs subtracted from opposite sides.
+59. A rectangular block with an arched opening: 120mm × 40mm × 80mm block with a Gothic arch-shaped extrusion subtracted through it.
+60. A hollow box with a lid slot: 80mm × 60mm × 50mm box walls 4mm thick, plus a 2mm-wide, 5mm-deep slot around the top rim for a sliding lid.
+61. A mushroom button: cylinder 30mm diameter and 6mm tall fused to a hemisphere 20mm radius on top, minus a flat on the underside.
+62. A socket head cap screw head blank: cylinder 16mm diameter and 10mm tall with a hexagonal pocket 7mm across flats and 5mm deep.
+63. A pipe cap: cylinder 40mm inner diameter and 5mm wall thick capped with a 5mm disc.
+64. A rectangular block with a slot and two holes that intersect the slot — block 100mm × 30mm × 20mm, slot 8mm × 20mm centred, two 10mm holes through the side intersecting the slot.
+65. A vise jaw face: flat block 80mm × 50mm × 15mm with a V-groove 10mm wide and 5mm deep across the face.
+66. A cylinder 50mm diameter and 60mm tall with a conical recess 30mm base and 20mm deep at the top.
+67. A box 100mm × 80mm × 30mm with a large rectangular cutout 60mm × 50mm centred in the top, leaving a picture-frame rim.
+68. A connecting rod blank: two cylinders 40mm and 30mm diameter and 20mm tall each, connected by a flat rectangular strap 80mm × 20mm × 10mm.
+69. A ball-and-socket blank: sphere 40mm diameter with a 20mm diameter flat cylindrical boss, and a matching cylindrical cup 42mm inner diameter and 25mm deep for the socket.
+70. A block with a keyhole-shaped through-hole: circular portion 20mm diameter at the top, slot 10mm wide and 30mm long below.
+71. A thick disc 80mm diameter and 25mm tall with an off-centre cylindrical hole 20mm diameter, centred 20mm from the disc centre.
+72. A rectangular housing with four counterbored mounting holes: 100mm × 80mm × 20mm, four holes 6mm clearance bore and 11mm × 4mm counterbore at corners.
+73. A flat plate 200mm × 100mm × 5mm with a large oval slot 100mm × 40mm cut through the centre.
+74. A bolt-and-nut shape (simplified): cylinder 20mm × 40mm (bolt body) fused to a hexagonal prism 30mm × 10mm (bolt head) at one end, with a 12mm through-hole subtracted through the hex head and body.
+75. A thin-walled box formed entirely by Boolean subtraction: solid 100mm × 80mm × 60mm block with an 88mm × 68mm × 56mm block subtracted from the top, leaving 6mm walls and floor.
+76. A rounded L-bracket: L-bracket with a large cylinder subtracted from the outer corner to create a smooth radius instead of a sharp outside corner.
+77. A mortised board: flat board 200mm × 80mm × 20mm with a rectangular mortise slot 30mm × 20mm × 20mm cut into one end face.
+78. A clamp body: flat C-shaped clamp — 100mm × 80mm × 20mm block with a 60mm × 40mm rectangular slot cut from one side, leaving a C-shape.
+79. A cylinder with three radial through-holes at 120-degree spacing: cylinder 50mm diameter and 80mm tall, holes 8mm diameter.
+80. A rounded rectangular block: 80mm × 50mm × 30mm with all four vertical corners replaced by 10mm-radius cylinders.
+81. A decorative initial letter B: flat extruded 3D shape, a rectangular upright 10mm × 10mm × 60mm with two D-shaped bumps on the right side.
+82. A rectangular frame with mitre corners: four rectangular bars 10mm × 10mm × 100mm arranged in a square frame, corners mitre-joined.
+83. A pipe reducer: two coaxial cylinders fused — large cylinder 50mm outer × 40mm inner × 40mm, small cylinder 30mm outer × 20mm inner × 40mm.
+84. A block with a conical countersink: 60mm × 40mm × 20mm block with a 90-degree cone subtracted from the top face, 20mm maximum diameter.
+85. A flat plate with a keyed slot: 100mm × 60mm × 8mm plate with a rectangular key slot 10mm × 4mm × 60mm along the centre.
+86. A stepped bore: cylinder 60mm diameter and 60mm tall with a three-step bore — 30mm diameter × 20mm deep, 20mm diameter × 20mm deep, 10mm diameter through the bottom.
+87. A block with corner notches: 80mm × 80mm × 20mm block with 20mm × 20mm × 20mm cubes subtracted from all four top corners.
+88. An interlocking block: 80mm × 40mm × 20mm block with a rectangular tenon 20mm × 10mm × 10mm sticking out from one face, and a matching mortise cut into the opposite face.
+89. A box 100mm × 80mm × 50mm with an angled front face: a large wedge-shaped solid subtracted from the front to create a 15-degree slanted face.
+90. A cylinder 60mm diameter and 80mm tall with two intersecting through-holes: one horizontal 15mm diameter, one vertical 15mm diameter, meeting in the centre.
+91. A cylindrical lens shape via intersection: cylinder 80mm diameter and 80mm tall intersected with an identical cylinder placed perpendicular.
+92. A flat plate with a pattern of hexagonal holes: 200mm × 150mm × 8mm plate with hexagonal cutouts 20mm across flats in a honeycomb arrangement.
+93. A pipe flange: cylinder 80mm diameter and 15mm tall fused to a disc 140mm diameter and 10mm tall, with four 12mm bolt holes through the flange.
+94. A castellated nut blank: hexagonal prism 30mm across flats and 25mm tall with six rectangular slots 4mm wide and 10mm deep cut evenly around the top face.
+95. A rectangular housing with a circular boss: 100mm × 80mm × 20mm block with a 30mm diameter, 15mm tall boss centred on top, and a 15mm through-bore in the boss.
+96. A ring with three evenly spaced ball seats: torus 80mm major radius, 10mm minor radius, with three 12mm hemisphere pockets at 120-degree intervals.
+97. A sphere cut into a figure resembling a Pac-Man: 80mm sphere with a 30-degree wedge-shaped volume subtracted from one side.
+98. A disc with radial fins: 100mm diameter, 10mm thick disc with eight rectangular fins 8mm × 8mm × 30mm fused radially around the perimeter.
+99. A rectangular block with a stepped pocket: 100mm × 80mm × 40mm block with a large pocket 70mm × 50mm × 20mm, and a smaller pocket 40mm × 30mm × 10mm at the bottom of the first.
+100. A mounting block with a through-slot and two cross-holes: 80mm × 40mm × 40mm block, longitudinal slot 10mm wide all the way through, two transverse holes 8mm diameter perpendicular to the slot.

--- a/workbench/categories/05-surface-modifications.md
+++ b/workbench/categories/05-surface-modifications.md
@@ -1,0 +1,112 @@
+---
+rank: 5
+name: Surface Modifications
+complexity: 5
+description: >
+  Modifying the surfaces of existing solids using fillet, chamfer, shell,
+  and offset operations. Includes rounding edges, bevelling corners, creating
+  hollow shells from solid objects, and controlling wall thickness.
+---
+
+## Examples
+
+1. A box 80mm × 60mm × 30mm with all twelve edges filleted to a 5mm radius.
+2. A box 100mm × 80mm × 40mm with only the top four edges filleted to 8mm, leaving bottom edges sharp.
+3. A cube 60mm on each side with all edges chamfered to 5mm × 45 degrees.
+4. A rectangular slab 120mm × 80mm × 10mm with all top-face edges filleted to 4mm.
+5. A cylinder 60mm diameter and 80mm tall with the top and bottom circular edges filleted to 5mm.
+6. A cylinder 50mm diameter and 60mm tall with the top edge chamfered at 45 degrees to a 6mm depth.
+7. A box 80mm × 60mm × 40mm shelled to a hollow box with 3mm wall thickness, open at the top.
+8. A sphere 80mm diameter shelled to create a hollow sphere with 3mm wall thickness, with a 10mm circular hole at the top.
+9. A cylinder 60mm diameter and 100mm tall shelled to a hollow cylinder with 4mm wall thickness and a closed top.
+10. A rectangular box 100mm × 80mm × 50mm shelled to 4mm walls, open at the top — like a storage tray.
+11. A box 80mm × 60mm × 30mm with the four vertical edges filleted to 10mm, giving it a can-like appearance.
+12. A box 100mm × 80mm × 40mm with asymmetric chamfers on the top edges: 8mm on the long sides, 5mm on the short sides.
+13. A cylinder 80mm diameter and 40mm tall with the bottom edge filleted to 10mm, creating a rounded base.
+14. A box 60mm × 60mm × 60mm with every edge filleted to 8mm — a very rounded cube, almost ball-like.
+15. A flat rectangular plate 200mm × 100mm × 5mm with all top edges chamfered to 1mm — a safety-chamfer finish.
+16. A box 100mm × 80mm × 50mm shelled with 3mm walls and an open face on the front, like a picture frame box.
+17. A cylinder 50mm diameter and 60mm tall with a 3mm shell, open at both ends — a hollow tube with rounded walls.
+18. A box 120mm × 80mm × 60mm with inside-facing fillet on all vertical edges: fillets that curve inward, 10mm radius.
+19. A tall rectangular column 30mm × 30mm × 200mm with all four vertical edges filleted to 5mm.
+20. A circular disc 100mm diameter and 20mm tall with the top rim edge filleted to 8mm, giving a smooth top surface.
+21. A rectangular block 80mm × 40mm × 30mm with a 5mm chamfer on all edges — a heavily chamfered block.
+22. A box 100mm × 80mm × 40mm with only the bottom four edges chamfered at 3mm, the top remaining sharp.
+23. An L-bracket (extruded L-profile 80mm × 60mm × 5mm each arm) with all outer edges filleted to 3mm.
+24. A hollow box with textured wall thickness: 100mm × 80mm × 60mm outer, shelled to 5mm uniform walls, open top.
+25. A cylinder 60mm diameter and 80mm tall with a 4mm shell thickness and closed ends — a solid thick-walled tube.
+26. A box 80mm × 60mm × 30mm with the four top vertical edges filleted to 6mm but the top horizontal edge left sharp.
+27. A half-cylinder 50mm diameter and 80mm tall (flat side down) with all outer curved edges filleted to 4mm.
+28. A sphere 60mm diameter with a 3mm shell — hollow ball. Open the shell on one face with a 20mm hole.
+29. A block 80mm × 80mm × 40mm with the top four edges filleted and the bottom edges chamfered — mixed finishing.
+30. A rectangular tray: box 200mm × 150mm × 30mm shelled to 2mm walls, open at the top, then the top rim edge filleted to 2mm.
+31. A cylinder 70mm diameter and 20mm tall with the outer circular edge at the top filleted to 8mm — like a hockey puck with rounded top edge.
+32. A box 100mm × 60mm × 40mm with a large-radius fillet on one edge only (one of the long top edges), 15mm radius.
+33. A hollow hemisphere: solid hemisphere 80mm radius shelled to 3mm thickness, open at the flat base.
+34. A tall thin box 20mm × 20mm × 150mm with all edges filleted to 3mm — a rounded rectangular rod.
+35. A box 100mm × 80mm × 50mm with the top face edges filleted to 10mm and a 4mm shell operation, open bottom — like a domed box lid.
+36. A flat disc 120mm diameter and 8mm thick with the top rim edge filleted to 3mm and the bottom rim chamfered to 2mm.
+37. An extruded T-shape (cross-section T, 100mm long) with all sharp outer edges filleted to 3mm.
+38. A cylinder 40mm diameter and 60mm tall with a variable-radius fillet: 8mm at the top, 3mm at the bottom.
+39. A box 80mm × 60mm × 30mm with the four corners of the top face filleted to a 10mm spherical corner (all three edges at each corner filleted together).
+40. A rectangular block 100mm × 80mm × 20mm with a 3mm shell making a shallow tray, then the top rim filleted to 2mm.
+41. A box 80mm × 60mm × 40mm with alternating chamfer and fillet on its twelve edges — chamfer on the horizontal edges, fillet on the vertical edges.
+42. A cylinder 80mm diameter and 60mm tall with both the top and bottom rims chamfered at 3mm, like a machined part.
+43. An octagonal prism 60mm across flats and 100mm tall with all eight vertical edges filleted to 2mm.
+44. A sphere 100mm diameter with a 5mm uniform shell — hollow ball with 5mm walls.
+45. A rectangular box 120mm × 80mm × 60mm with a 5mm shell but with one face left solid (the bottom) and the rest hollow.
+46. A flat frame (rectangular ring) 200mm × 150mm outer, 180mm × 130mm inner, 15mm thick — shelled from a solid block with inner and outer faces open.
+47. A cylinder 60mm diameter and 40mm tall with the top face filleted to create a dome-like top — 20mm radius fillet on the top circular edge.
+48. A box 60mm × 60mm × 60mm with only the eight corner edges filleted to 5mm (the twelve edges where two faces meet), leaving face-edge intersections sharp.
+49. A rectangular bar 200mm × 10mm × 10mm with all four long edges filleted to 2mm — a rounded bar stock profile.
+50. A hollow cylinder (pipe) with chamfered ends: outer 40mm, inner 30mm diameter, 100mm long, with a 2mm chamfer on both inner and outer edges at each end.
+51. A box 80mm × 60mm × 30mm with a very generous fillet on the top two long edges only, 12mm radius — giving a soft pillow-like top.
+52. A rectangular block 100mm × 80mm × 50mm with the bottom corners filleted to 15mm — rounded base corners only.
+53. A thin flat shell: box 120mm × 80mm × 40mm shelled to 1.5mm — like a product enclosure skin.
+54. A cylinder 50mm diameter and 30mm tall with a 5mm chamfer on the top outer edge and a 3mm fillet on the bottom outer edge.
+55. A box 80mm × 60mm × 40mm, shelled to 3mm, with the top face removed but a 10mm-wide lip remaining around the top opening.
+56. A hexagonal prism 40mm across flats and 60mm tall with all six vertical edges filleted to 4mm, giving it a rounded hexagonal appearance.
+57. A flat oval (stadium shape) 120mm × 60mm and 20mm tall, with the top rim edge filleted to 5mm.
+58. A box 100mm × 80mm × 50mm with all four top edges filleted to 8mm and then the resulting solid shelled to 3mm, open at the bottom.
+59. A block 80mm × 60mm × 40mm where the four vertical edges on one side are filleted to a 20mm radius — very rounded on one end.
+60. A cylindrical container: cylinder 80mm diameter and 120mm tall, shelled to 3mm, open at the top, with a 2mm fillet on the top inner and outer rim edges.
+61. A flat plate 150mm × 100mm × 6mm with all edges chamfered to 45° × 1.5mm — a safety-edged plate.
+62. A rounded box (all edges filleted): 80mm × 60mm × 40mm with 6mm fillets everywhere — like a modern electronic device housing.
+63. A tray with filleted corners: 200mm × 150mm × 30mm, 3mm shell, open top, all inner and outer corners filleted to 5mm.
+64. A cylinder 60mm diameter and 80mm tall with a 3mm shell and a small circular hole 15mm diameter in the side wall.
+65. A box 100mm × 80mm × 50mm with the two long bottom edges chamfered at 2mm and all other edges filleted at 3mm.
+66. A flat plate 200mm × 100mm × 8mm with all four face-perimeter edges filleted to 3mm, giving it a smooth all-around edge profile.
+67. A sphere 100mm diameter shelled to 4mm with a flat cut at the bottom so it sits upright — open-top bowl shape.
+68. A rectangular housing 80mm × 60mm × 40mm with 3mm walls (shell) and four mounting lugs (bosses) on the base, each 8mm diameter and 5mm tall.
+69. A box 60mm × 60mm × 30mm with an inside fillet: the inner corner of an L-shaped cross-section filleted to 5mm — smooth inner transition.
+70. A cylinder 100mm diameter and 150mm tall with a very aggressive shell — 10mm wall thickness — creating a heavyweight tube.
+71. A flat disc 80mm diameter and 10mm tall shelled to 2mm thickness, open at one flat face — like a shallow drum shell.
+72. A box 120mm × 80mm × 60mm with all edges filleted to 3mm and then the top face filleted again to a dome — top edge 15mm secondary fillet.
+73. A U-channel profile extruded 150mm with all interior edges filleted to 4mm, creating smooth channel corners.
+74. A rectangular block 100mm × 60mm × 40mm with the two top long edges filleted to a very large radius — 30mm — creating a half-round top surface.
+75. A hollow cone: solid cone 60mm base and 80mm tall, shelled to 3mm, open at the base.
+76. A cylinder with a chamfered bore: outer cylinder 50mm diameter and 60mm tall, 30mm inner bore, with a 3mm chamfer on both ends of the bore.
+77. A box 80mm × 60mm × 40mm with four 3mm chamfers on the top face perimeter edges — countersunk-style chamfering all around the top.
+78. A compound fillet: box 100mm × 80mm × 50mm with 10mm fillets on the four vertical edges and 5mm fillets on the eight horizontal edges.
+79. A flat rectangular frame (wall picture frame shape): 200mm × 150mm outer, 150mm × 100mm inner cutout, 25mm thick, all inner edges filleted to 5mm.
+80. A bowl created by shelling a half-sphere: 100mm radius hemisphere shelled to 4mm, open at the flat base.
+81. A box 80mm × 60mm × 30mm with the entire box shelled to 2.5mm walls and the top rim edge filleted to 2mm — like a thin plastic container.
+82. A rectangular bar 150mm × 30mm × 15mm with all four long edges chamfered to 3mm × 45°, creating an octagonal bar profile.
+83. A disc 90mm diameter and 15mm tall with the curved side-wall edge filleted to 7mm top and bottom, giving a lens-shaped appearance.
+84. A box 100mm × 80mm × 50mm with the four top face corners filleted to a sphere-corner — 10mm radius fillet on all three meeting edges at each corner.
+85. A tall thin post 15mm × 15mm × 200mm with all four long edges filleted to 3mm — rounded rectangular post.
+86. A cylinder 80mm diameter and 60mm tall with the outer surface offset outward by 2mm — slightly larger version via offset.
+87. A box 80mm × 60mm × 40mm with three edges filleted (two on top, one vertical) and the remaining edges left sharp.
+88. A flat L-profile plate (each arm 80mm × 8mm, extruded 5mm thick) with all outer edges filleted to 2mm.
+89. A sphere 60mm diameter with a 4mm shell and two flat cuts removing opposite hemispheres — a lens-shaped shell.
+90. A very rounded rectangular solid: box 80mm × 60mm × 40mm with 20mm fillets on all four vertical edges, creating a near-cylindrical shape.
+91. A box 100mm × 80mm × 50mm with a 3mm shell, then filled back with a 5mm thick solid slab floor — shelled box with a solid base.
+92. A cylinder 60mm diameter and 80mm tall with a shell and then a helical-approximation groove: subtract a 5mm wide strip wrapping around the outside.
+93. A flat slab 200mm × 150mm × 10mm with the top two long edges filleted to 5mm and the bottom two chamfered at 45° × 3mm.
+94. A box 80mm × 60mm × 40mm where one face has an inward boss retained: shelled to 3mm but with a 30mm diameter × 8mm solid boss protruding inward from the bottom face.
+95. A hemisphere 60mm radius with a 3mm shell, open at the base, with the top area cut flat — a hard-hat dome shape.
+96. A rectangular block 80mm × 40mm × 30mm with all edges filleted to different radii — 8mm on top four edges, 5mm on four vertical, 3mm on four bottom edges.
+97. A flat plate 120mm × 100mm × 5mm with the four outer corners filleted to 15mm — a rounded-corner plate like a phone back.
+98. A box 100mm × 80mm × 60mm with a 4mm shell and four vertical through-holes 8mm diameter bored through the shell walls at each corner — mounting holes in a hollow enclosure.
+99. A cylinder 80mm diameter and 40mm tall with a very deep shell: 15mm wall thickness, open at one end — a thick-walled cup.
+100. A rectangular block 100mm × 60mm × 40mm with full 6mm fillet on every edge (all twelve), creating a smooth, blob-like solid with no sharp edges anywhere.

--- a/workbench/categories/06-arrays-patterns.md
+++ b/workbench/categories/06-arrays-patterns.md
@@ -1,0 +1,112 @@
+---
+rank: 6
+name: Arrays and Patterns
+complexity: 5
+description: >
+  Repeating geometry using GridLocations, PolarLocations, and manual
+  Locations contexts. Covers linear arrays, rectangular grids, circular
+  patterns, irregular placements, and pattern-based subtractions.
+---
+
+## Examples
+
+1. A flat plate 200mm × 150mm × 8mm with a 4×3 grid of 10mm diameter through-holes, evenly spaced 40mm apart.
+2. A flat plate 160mm × 160mm × 6mm with a 5×5 grid of 12mm diameter holes, 30mm pitch.
+3. A circular flange disc 120mm diameter and 15mm thick with six 8mm bolt holes on a 90mm bolt circle diameter, equally spaced.
+4. A large disc 150mm diameter and 20mm thick with eight 10mm holes on a 120mm bolt circle.
+5. A flat plate 200mm × 50mm × 8mm with a row of ten 8mm holes, 18mm apart along the centreline.
+6. A square plate 100mm × 100mm × 5mm with a polar array of eight 6mm holes on a 70mm bolt circle.
+7. A flat bar 200mm × 20mm × 5mm with equally spaced holes every 25mm along the length — eight holes of 6mm diameter.
+8. A disc 80mm diameter and 10mm tall with a polar array of six fins (rectangular tabs 10mm × 3mm × 5mm) equally spaced around the outer edge.
+9. A cylindrical ring 100mm outer diameter, 80mm inner diameter and 20mm tall, with twelve equally spaced 6mm holes through the ring wall.
+10. A flat plate 200mm × 100mm × 6mm with a honeycomb pattern of 15mm hexagonal holes, rows offset by half a pitch.
+11. A base plate 150mm × 150mm × 8mm with four 6mm countersunk mounting holes, one at each corner, 15mm from each edge.
+12. A flat circular plate 120mm diameter and 6mm thick with a ring of eight 5mm peg-holes on a 90mm PCD and four mounting holes on a 100mm PCD.
+13. A rectangular frame 200mm × 150mm × 10mm wall, with a regular grid of 8mm holes along each arm — five holes per arm.
+14. A flat plate 180mm × 120mm × 8mm with alternating hole sizes in a grid: 10mm and 6mm holes alternating in a 4×3 pattern.
+15. A disc 200mm diameter and 15mm thick used as a clock face, with twelve 5mm peg holes equally spaced on a 170mm circle for clock numerals.
+16. A square plate 100mm × 100mm × 4mm with a 3×3 grid of raised cylindrical bosses 8mm diameter and 3mm tall on the top face.
+17. A base 200mm × 200mm × 10mm with a 4×4 grid of 8mm × 8mm × 5mm square bosses — like LEGO stud arrangement.
+18. A cylinder 60mm diameter and 80mm tall with a polar array of eight longitudinal ribs (rectangular fins 4mm × 4mm × 80mm) fused around the outside.
+19. A flat panel 300mm × 200mm × 3mm with a grid of rectangular ventilation slots 30mm × 4mm in a 5×4 pattern, 10mm spacing.
+20. A round plate 150mm diameter and 12mm thick with a polar array of six D-shaped cutouts, evenly spaced around the rim, each 20mm × 10mm.
+21. A rectangular plate 200mm × 100mm × 6mm with a diagonal grid of 8mm holes at 45 degrees.
+22. A cylinder 80mm diameter and 20mm tall with twelve evenly spaced triangular notches around its rim — like a crown.
+23. A flat square 100mm × 100mm × 5mm with a 10×10 grid of small 3mm diameter shallow pits 1mm deep — like a dimple texture.
+24. A pipe flange 120mm outer diameter and 15mm thick with four M10 bolt holes (11mm dia) on a 90mm bolt circle at 90-degree intervals.
+25. A flat plate 160mm × 60mm × 6mm with two parallel rows of 6mm holes — eight holes per row, 20mm pitch.
+26. A disc 100mm diameter and 8mm thick with a polar array of sixteen 4mm holes on an 80mm PCD, like a pattern for encoder disc.
+27. A rectangular grid of freestanding cylinders on a base plate: 4×4 grid of cylinders 10mm diameter and 30mm tall, on a 120mm × 120mm × 5mm base plate, 30mm pitch.
+28. A flat plate 200mm × 200mm × 6mm with a concentric ring of holes: 8 holes on a 60mm circle, 12 holes on a 100mm circle, 16 holes on a 140mm circle.
+29. A circular plate 150mm diameter and 10mm thick with three groups of four holes — three clusters at 120-degree spacing, each cluster a 2×2 grid of 6mm holes.
+30. A rectangular base 200mm × 150mm × 10mm with mounting lugs: four 25mm × 20mm × 8mm pads with 6mm holes, one at each corner.
+31. A flat panel 250mm × 200mm × 4mm with a 6×5 grid of 20mm × 15mm oval slots.
+32. A drum-like cylinder 100mm diameter and 30mm tall with 24 equally spaced vertical slots 3mm wide through the outer wall.
+33. A flat plate 180mm × 60mm × 8mm with a repeating pattern of two circular holes and one oval slot in groups of three, four groups along the length.
+34. A base plate 200mm × 200mm × 10mm with a polar array of six M6 threaded insert pockets (6.8mm diameter, 8mm deep) on a 150mm circle.
+35. A fan blade disc: 80mm diameter hub disc 20mm thick with five equally spaced rectangular blade stubs (40mm × 8mm × 5mm) arranged radially.
+36. A flat sheet 300mm × 200mm × 2mm with a 3×4 grid of 50mm × 30mm rectangular cutouts — like a vent grille.
+37. A solid cylinder 50mm diameter and 60mm tall with a polar array of five longitudinal grooves (10mm wide, 5mm deep) cut around the outside.
+38. A flat plate 150mm × 150mm × 6mm with a polar arrangement of eight elongated slots (30mm × 5mm) arranged like wheel spokes.
+39. A circular plate 100mm diameter and 8mm thick with a 4-hole bolt pattern at 60mm PCD and a central 20mm hole.
+40. A base plate 200mm × 100mm × 8mm with two rows of M4 insert pockets (4.5mm dia, 6mm deep): six in each row, 30mm apart.
+41. A square plate 80mm × 80mm × 5mm with nine equally spaced circular bosses (8mm diameter, 3mm tall) in a 3×3 grid — rubber-foot mounting pads.
+42. A cylinder 60mm diameter and 40mm tall with a polar array of eight 5mm-deep hemispherical dimples around its side wall.
+43. A flat rectangular panel 200mm × 100mm × 4mm with a staggered grid of 8mm holes — two rows of five holes, rows offset by half pitch.
+44. A disc 120mm diameter and 10mm thick with three rows of holes in concentric rings: 6 holes on 40mm PCD, 10 holes on 70mm PCD, 14 holes on 100mm PCD.
+45. A long bar 300mm × 20mm × 8mm with a polar (circular arc) array of eleven 6mm holes on a large-radius arc.
+46. A flat ring 120mm outer diameter, 80mm inner diameter, 8mm thick with twelve evenly spaced 5mm holes through the ring.
+47. A square tile 100mm × 100mm × 10mm with a 5×5 grid of pyramidal bumps 5mm base and 3mm tall on the top face.
+48. A cylinder 100mm diameter and 20mm tall with a polar array of 24 gear-tooth-like bosses evenly spaced around the outer rim, each 4mm wide and 6mm tall.
+49. A flat plate 200mm × 100mm × 6mm with a cross-grid pattern of slots: rows of 40mm × 3mm slots and columns of 3mm × 40mm slots, creating a mesh-like appearance.
+50. A base 150mm × 100mm × 10mm with a 3×2 grid of circular standoff bosses — each 12mm diameter and 8mm tall with a 3mm through-hole.
+51. A flat disc 80mm diameter and 4mm thick with a sunflower pattern of 34 small 4mm holes arranged in Fibonacci spirals.
+52. A rectangular plate 200mm × 150mm × 5mm with six 20mm × 5mm rectangular key slots arranged in a 2×3 grid.
+53. A tube 60mm outer diameter and 4mm wall, 150mm long, with four rows of four 6mm holes each in a grid.
+54. A flat square plate 120mm × 120mm × 8mm with a polar array of eight L-shaped slots (10mm × 5mm turning to 5mm × 10mm), used as a bayonet-lock pattern.
+55. A cylinder 80mm diameter and 50mm tall with 20 equally spaced radial fins (5mm thick, 20mm tall, 15mm wide) fused around the outside — like a heat sink.
+56. A flat base 200mm × 100mm × 5mm with raised pegs in a 4×2 grid: eight pegs each 8mm diameter and 15mm tall, 40mm pitch.
+57. A flat plate 300mm × 200mm × 3mm with a grid of diamond-shaped holes rotated 45 degrees, 5×3 grid, each diamond 20mm × 10mm.
+58. A circular platform 150mm diameter and 15mm thick with a polar array of six 20mm-wide and 30mm-tall rectangular towers fused to the top.
+59. A flat panel 250mm × 150mm × 4mm with evenly spaced 5mm-wide cable management slots — two rows of four slots each.
+60. A flat strip 200mm × 10mm × 4mm with a linear array of 20 small 3mm holes every 10mm — a perf strip.
+61. A disc 100mm diameter and 12mm thick with a flower petal array of six teardrop-shaped cutouts, tips pointing toward the centre, evenly spaced.
+62. A base plate 180mm × 120mm × 8mm with 2×3 grid of rubber foot recesses: circular pockets 12mm diameter and 2mm deep.
+63. A cylinder 100mm diameter and 30mm tall with alternating large and small holes around the circumference: eight 10mm and eight 6mm holes alternating.
+64. A flat panel 200mm × 200mm × 5mm with a 4×4 grid of dome-topped bosses (10mm diameter, 8mm tall with hemispherical tops).
+65. A rectangular base 150mm × 100mm × 10mm with a linear array of five triangular fins 20mm tall and 5mm thick along the centreline.
+66. A flat plate 160mm × 120mm × 6mm with a grid of chamfered holes: 4×3 grid of 12mm holes each with a 1mm × 45° chamfer on both sides.
+67. A circular plate 120mm diameter and 8mm thick with a pattern of sixteen 5mm-tall cylindrical posts on a 90mm circle — connector pin pattern.
+68. A flat strip 200mm × 30mm × 5mm with seven evenly spaced 10mm wide rectangular notches cut halfway through the width — a comb strip.
+69. A base plate 200mm × 200mm × 10mm with a polar array of twelve 5mm-deep V-groove slots, evenly spaced around the edge perimeter.
+70. A flat ring 100mm outer, 60mm inner diameter, 6mm thick, with twelve rectangular tabs 10mm × 5mm × 3mm fused at equal spacing to the outer rim.
+71. A flat plate 180mm × 120mm × 5mm with alternating rows of circular and slot-shaped holes forming a brick-bond pattern.
+72. A cylinder 80mm diameter and 60mm tall with three polar-array rings of holes at different heights: four holes at bottom, six at mid, eight at top.
+73. A square base 100mm × 100mm × 10mm with a 2×2 grid of large standoffs (20mm diameter, 15mm tall, 4mm through-hole) plus four small feet (8mm diameter, 3mm tall) at the corners.
+74. A flat disc 200mm diameter and 5mm thick with a Braille-like array of small 3mm-diameter raised dots arranged in a 10×8 grid.
+75. A rectangular frame 200mm × 150mm × 15mm wall with a grid of 5mm holes on 20mm centres across each face of the frame.
+76. A flat plate 200mm × 100mm × 6mm with a two-zone hole pattern: dense 5mm holes at 10mm pitch in the left half, sparse 10mm holes at 25mm pitch in the right half.
+77. A cylinder 80mm diameter and 20mm tall with a polar array of twelve 5mm wide by 5mm deep radial slots — like a turbine wheel.
+78. A flat plate 200mm × 200mm × 4mm with a 5×5 grid of square holes 20mm × 20mm with 5mm spacing — a mesh panel.
+79. A bar 200mm × 15mm × 8mm with a row of triangular teeth 8mm wide and 5mm tall along one edge — a rack for a rack-and-pinion mechanism.
+80. A round plate 150mm diameter and 10mm thick with three concentric rings of bosses: six 8mm bosses at 50mm radius, eight 8mm bosses at 80mm radius, ten 8mm bosses at 120mm radius.
+81. A flat panel 300mm × 200mm × 3mm with a 6×4 grid of louvred slots: 30mm × 5mm slots angled at 30 degrees.
+82. A disc 100mm diameter and 8mm thick with a spiral arrangement of 16 small 4mm holes at increasing radii.
+83. A long bar 400mm × 20mm × 10mm with a repeating pattern of three alternating hole types every 50mm: circular 8mm, oval 15mm × 6mm, circular 8mm.
+84. A flat plate 150mm × 100mm × 5mm with a 4×3 grid of embossed circular labels (raised rings 20mm OD, 14mm ID, 1mm tall).
+85. A base 200mm × 150mm × 12mm with a 3×2 arrangement of rectangular pockets 40mm × 30mm × 5mm deep — component trays.
+86. A circular plate 100mm diameter and 6mm thick with an 8-fold symmetry pattern: eight teardrop slots arranged like a propeller around the centre.
+87. A flat strip 250mm × 20mm × 3mm with a periodic wave-like cutout pattern: alternating semicircular bites 8mm radius from each long edge.
+88. A square base 80mm × 80mm × 8mm with a 3×3 grid of threaded insert pockets plus a central 20mm clearance hole.
+89. A cylinder 60mm diameter and 80mm tall with a diagonal grid of 5mm holes crossing the surface at 45-degree helix angle.
+90. A flat plate 200mm × 100mm × 5mm with a 5×3 grid of wing-shaped cutouts, each wing 25mm × 12mm.
+91. A ring 80mm outer and 60mm inner diameter, 10mm thick, with sixteen triangular teeth 8mm tall on the inner rim — like an internal ring gear.
+92. A flat disc 200mm diameter and 8mm thick with a bolt hole pattern matching an ISO 200 pipe flange: eight M20 holes on a 160mm PCD.
+93. A rectangular base 200mm × 150mm × 10mm with three rows of nut capture pockets (hexagonal, 7mm across flats, 4mm deep): five pockets per row.
+94. A flat panel 300mm × 150mm × 4mm with a 2×8 grid of 18mm round corner squares — slots with semicircular ends, like index card slots.
+95. A circular plate 150mm diameter with a polar array of twelve identical sector cutouts — like a pie with alternating solid and void sectors, 15 degrees each.
+96. A base 200mm × 200mm × 15mm with 25 equally spaced cylindrical pockets (20mm dia, 12mm deep) in a 5×5 grid — a parts organiser tray.
+97. A cylinder 100mm diameter and 20mm tall with a polar array of 30 radial slots 2mm wide and 10mm deep around the outer rim — a slotted disc encoder wheel.
+98. A flat plate 200mm × 120mm × 6mm with a staggered 5×3 brick-bond pattern of 25mm × 10mm rectangular slots.
+99. A circular base 120mm diameter and 10mm thick with six evenly spaced T-slots (T cross-section, 8mm wide stem, 14mm wide head, 10mm deep) on a 80mm radius.
+100. A flat aluminium panel 400mm × 300mm × 3mm with a 10×8 grid of small 4mm diameter holes on 35mm pitch — a perforated mounting panel.

--- a/workbench/categories/07-simple-objects.md
+++ b/workbench/categories/07-simple-objects.md
@@ -1,0 +1,112 @@
+---
+rank: 7
+name: Simple Everyday Objects
+complexity: 6
+description: >
+  Common household and everyday objects that combine multiple primitives,
+  extrusions, booleans, and surface modifications. Objects should be
+  recognisable and functional in shape, even if simplified.
+---
+
+## Examples
+
+1. A simple coffee mug: cylindrical body 80mm diameter and 90mm tall with 3mm walls, a D-shaped handle on the side, open at the top.
+2. A shot glass: tapered cylinder 45mm top diameter, 38mm bottom, 55mm tall, 2.5mm wall, open top.
+3. A flower pot: tapered cylinder wider at top — 120mm top diameter, 90mm bottom diameter, 130mm tall, 4mm wall, closed bottom with a 10mm drainage hole.
+4. A simple bowl: hemispherical bowl 180mm diameter and 80mm deep, 4mm walls, flat rim, open top.
+5. A salad bowl: wide shallow bowl 250mm diameter, 100mm deep, 4mm walls, flat base.
+6. A round plate: flat disc 250mm diameter, 25mm tall, with a 5mm raised rim around the edge.
+7. A simple mug without a handle: thick-walled cylinder 75mm outer diameter, 3mm wall, 80mm tall, open top, flat bottom.
+8. A small bucket: tapered cylinder with a flat base — 100mm top diameter, 85mm bottom diameter, 90mm tall, 3mm walls, no handle.
+9. A simple candle holder: cylinder 60mm outer diameter, 50mm inner diameter, 80mm tall — hollow cylinder with no top or bottom, wide enough to hold a standard candle.
+10. A wine glass stem and base only (no cup): disc base 80mm diameter and 5mm thick connected to a thin cylinder stem 10mm diameter and 100mm tall.
+11. A simple rolling pin: cylinder 50mm diameter and 250mm long, with two cylinder handle stubs 25mm diameter and 30mm long on each end.
+12. A bathroom soap dish: rectangular tray 120mm × 80mm × 20mm with 3mm walls, open top, and four oval drainage holes 25mm × 8mm in the base.
+13. A simple door stopper: triangular wedge shape, 80mm wide, 60mm long, 30mm at the thick end, tapering to near-zero.
+14. A pencil holder: a cylinder 70mm outer diameter and 100mm tall, 3mm walls, open top.
+15. A square cup: rectangular box 70mm × 70mm and 80mm tall, 3mm walls, open top.
+16. A simple coaster: flat disc 100mm diameter and 5mm thick, with a 3mm raised rim around the top edge.
+17. A square coaster: flat square 100mm × 100mm and 5mm thick, with a 2mm raised rim around all edges of the top face.
+18. A simple wall hook: L-shaped bracket 30mm wide, wall mount arm 60mm long and 10mm thick, hook arm 40mm long curving downward.
+19. A key fob: flat oval 50mm × 30mm and 6mm thick with a 5mm hole near one end for a key ring.
+20. A simple wine bottle stopper: cylinder 19mm diameter and 30mm long (the cork portion), topped by a wider flat disc 40mm diameter and 10mm thick (the handle).
+21. A simple bookend: L-shaped base — 120mm × 80mm foot and 150mm × 80mm vertical arm, both 5mm thick.
+22. A small piggy bank shape (simplified): sphere 80mm diameter sitting on a cylinder base 30mm diameter and 20mm tall, with a coin slot 30mm × 3mm on top.
+23. A letter tray: flat rectangular tray 250mm × 180mm × 30mm, 2.5mm walls and base, open top.
+24. A desk organiser pen cup: rectangular box 80mm × 80mm and 120mm tall, 3mm walls, open top.
+25. A simple doorknob: sphere 50mm diameter attached to a cylinder stem 20mm diameter and 40mm long.
+26. A small shelf bracket: L-shape — horizontal arm 150mm × 30mm × 8mm, vertical arm 100mm × 30mm × 8mm.
+27. A toothbrush holder: cylinder 80mm diameter and 120mm tall, walls 3mm, open top.
+28. A simple cheese knife: flat blade 150mm × 20mm × 3mm with a rounded tip, joined to a cylinder handle 20mm diameter and 80mm long.
+29. A simple spatula: flat blade 100mm × 40mm × 3mm with five 8mm holes in a 1×5 row, joined to a handle 20mm × 15mm × 120mm.
+30. A coat hook: curved arm 15mm diameter, 80mm long, with a wall mounting plate 60mm × 40mm × 8mm at the base.
+31. A small picture frame: rectangular outer 200mm × 150mm × 20mm, inner cutout 160mm × 110mm, 15mm wall, 5mm deep lip at the back to hold a print.
+32. A simple jar lid: flat disc 80mm diameter and 10mm tall with a small cylindrical handle 20mm diameter and 15mm tall on top.
+33. A napkin ring: cylinder 50mm outer diameter, 38mm inner diameter, 30mm tall.
+34. A simple ring box exterior: rectangular box 60mm × 50mm × 40mm with 3mm walls and hinged lid gap — indicate the lid as a separate box 60mm × 50mm × 15mm.
+35. A kitchen timer knob: cylinder 35mm diameter and 25mm tall with a flat on one side, sitting on a smaller cylinder 15mm diameter and 10mm tall.
+36. A simple cake ring mould: cylinder 200mm inner diameter, 3mm wall, 80mm tall, no top or bottom — open cylinder.
+37. A small funnel: cone 80mm top diameter tapering to a cylinder 20mm diameter × 30mm long spout, 2mm walls throughout.
+38. A simple clothespeg (spring peg shape): two flat arms 80mm × 10mm × 5mm joined at one end by a rounded joint, open at the other.
+39. A simple comb: flat base 150mm × 15mm × 4mm with a row of 20 teeth, each 4mm wide, 2mm gap, 25mm tall.
+40. A banana hook for a bunch of bananas: C-shaped hook in the horizontal plane, arm radius 60mm, wire diameter 10mm, flat wall-mount 60mm × 40mm × 8mm.
+41. A simple egg cup: cylinder 55mm inner diameter and 45mm deep for the egg cup portion, sitting on a wider base disc 80mm diameter and 10mm tall.
+42. A small flower vase: cylinder 50mm outer diameter, 42mm inner, 150mm tall, with a slightly flared top — top 54mm outer diameter.
+43. A simple tray with handles: rectangular tray 300mm × 200mm × 40mm, 3mm walls, two cylindrical handles 20mm diameter on each short end.
+44. A simple cube puzzle piece: cube 40mm on each side with a half-sphere 15mm radius peg on one face and a matching socket on the opposite face.
+45. A jam jar lid: flat disc 80mm diameter and 12mm tall with knurled outer edge (approximate with octagonal outer perimeter), inner rim 2mm for sealing.
+46. A simple curtain ring: torus 35mm major radius and 5mm minor radius with a flat squared section where it opens, approximated as a near-complete torus.
+47. A simple key: flat body 60mm × 15mm × 3mm with a round bow (ring) 25mm outer, 15mm inner at one end, and a simple 3-bit profile at the other end.
+48. A simple cork board pin: sphere 8mm diameter (the head) on a cylinder 1.5mm diameter and 25mm long (the pin).
+49. A simple lock body exterior: rectangular box 50mm × 30mm × 60mm with a U-shaped shackle 30mm wide, 15mm wire diameter, 40mm long legs sticking up from the top.
+50. A small plant pot saucer: flat shallow disc-shaped tray 150mm outer diameter and 20mm tall, 3mm walls, with a 2mm raised inner rim 100mm diameter to hold the pot.
+51. A simple kitchen timer body: cylindrical case 70mm diameter and 80mm tall, with a flat front face and a dial knob 30mm diameter on top.
+52. A small picture ledge: rectangular shelf 300mm × 60mm × 20mm with a 10mm-tall front lip.
+53. A simple bowl for a mixing bowl: wide hemisphere 200mm diameter and 120mm deep, 4mm walls, flat rim 15mm wide.
+54. A simple candle: cylinder 25mm diameter and 150mm tall, with a flat base.
+55. A simple teacup saucer: flat oval disc 140mm × 120mm and 15mm tall with a raised ring 70mm diameter and 5mm tall in the centre for the cup to rest in.
+56. A simple pepper shaker: cylinder 45mm diameter and 100mm tall with a domed top, 2mm walls, with six 3mm holes in the top dome.
+57. A simple toilet paper roll holder: T-shaped bracket — vertical arm 100mm × 15mm × 8mm mounting on a wall, horizontal cylinder 38mm diameter and 130mm long extending from the middle.
+58. A simple drawer knob: hemisphere 30mm diameter as the grip, with a cylinder 8mm diameter and 20mm long as the mounting stem.
+59. A simple snow globe base: dome 100mm outer diameter and 80mm tall, hemisphere, sitting on a flat disc base 120mm diameter and 20mm tall.
+60. A simple butter dish cover: half-cylinder 120mm × 80mm cross-section, 80mm tall, 3mm walls, open at the base.
+61. A simple book stand (music stand style): flat rectangular ledge 200mm × 30mm × 5mm at a 70-degree angle, supported by a triangular brace 30mm tall at the back.
+62. A simple spice rack shelf: 300mm × 80mm × 15mm flat shelf with two cylindrical pegs 10mm diameter and 20mm tall to prevent jars from rolling off.
+63. A simple pill organiser cell (one compartment): rectangular box 20mm × 15mm × 10mm with 1.5mm walls, open top.
+64. A simple planter box: rectangular box 300mm × 150mm × 200mm, 5mm walls, open top, with four 10mm drainage holes in the base.
+65. A simple bookend set (one piece): L-shape — base 120mm × 80mm × 8mm, vertical arm 150mm × 80mm × 8mm.
+66. A simple letter opener: flat blade 180mm × 15mm × 2mm tapering to a thin edge, with a handle 80mm × 20mm × 8mm.
+67. A simple soap bar: rounded rectangular solid 90mm × 55mm × 30mm with 8mm corner radii.
+68. A simple toothpaste tube cap: cylinder 22mm outer diameter and 20mm tall, open at one end with internal threads approximated by a slight taper.
+69. A simple storage box lid: flat plate 120mm × 80mm and 10mm deep, 3mm walls on three sides and the top, open bottom, snapping over a matching box.
+70. A simple coin tray: shallow square tray 100mm × 100mm × 15mm, 3mm walls, open top.
+71. A simple wine bottle holder (one slot): a block 120mm × 120mm × 80mm with a cylindrical bore 38mm diameter through the side to cradle a wine bottle on its side.
+72. A simple napkin holder: two flat plates 150mm × 100mm × 5mm connected by a flat base 150mm × 80mm × 5mm at the bottom, spaced 30mm apart.
+73. A simple cable drum end cap: disc 80mm diameter and 10mm thick with a central hex boss 20mm across flats and 15mm tall.
+74. A simple tea candle holder: flat disc 50mm diameter and 8mm tall, hollowed out 38mm diameter and 6mm deep in the centre.
+75. A simple door number plate: rectangular plate 100mm × 40mm × 5mm with two 4mm mounting holes, with raised digit-shaped bosses suggesting the number "42".
+76. A simple vase: cylinder 60mm outer diameter, 3mm wall, 200mm tall, with a slightly flared top opening to 70mm.
+77. A simple coin bank slot lid: flat disc 90mm diameter and 8mm thick with a coin slot 30mm × 3mm cut through the top.
+78. A simple ice cube tray cell: rectangular box 35mm × 35mm × 30mm with 2mm walls, open top, rounded inside bottom corners.
+79. A simple comb for wide hair: flat base 200mm × 15mm × 4mm with a row of 20 wide teeth 6mm wide and 30mm tall.
+80. A simple tablet stand: L-shaped base — flat plate 100mm × 80mm × 5mm, vertical plate 120mm × 80mm × 5mm, with a 10mm-deep slot 4mm wide cut horizontally across the vertical plate to hold a tablet's edge.
+81. A simple wall clock body: disc 300mm diameter and 20mm thick with a 10mm centre hole, flat front and back faces.
+82. A simple stamp block: rectangular block 50mm × 30mm × 25mm with a 10mm cylindrical grip boss on top.
+83. A simple soap pump bottle body: cylinder 60mm outer diameter and 3mm wall, 150mm tall, with a flat base and a 20mm neck 40mm tall at the top.
+84. A simple paper clip: bent wire shape — a large outer loop and a smaller inner loop, wire 1.5mm diameter, total size 32mm × 8mm.
+85. A simple mouse-shaped decoration: egg-shape body 60mm × 40mm × 30mm with two small hemisphere ears on top 12mm each, and a thin tail cylinder 3mm diameter and 60mm long.
+86. A simple bird feeder tray: shallow round tray 200mm diameter and 25mm tall, 3mm walls, with a central 15mm hole for mounting on a post.
+87. A simple piggy bank: sphere 100mm diameter, flat bottom cut, coin slot 32mm × 2.5mm on top, snout cylinder 20mm diameter and 8mm tall on front, two small coin-shaped ear discs.
+88. A simple wall-mount key holder: flat plate 200mm × 80mm × 8mm with five small hook cylinders (8mm diameter, 20mm long) projecting forward along the bottom edge, and two mounting holes at the top.
+89. A simple modelling clay roller: cylinder 40mm diameter and 150mm long with a 15mm diameter handle cylinder through the centre, 200mm long.
+90. A simple ice cream scoop: hemisphere bowl 45mm diameter attached to a cylinder handle 20mm diameter and 120mm long.
+91. A simple tyre pressure gauge body: cylinder 30mm diameter and 80mm long with a 15mm diameter pressure nozzle stub 20mm long at one end.
+92. A simple phone stand: angled wedge base 120mm × 80mm × 10mm, with a vertical slot 4mm wide and 30mm deep cut across the top face for a phone to sit in.
+93. A simple cable management clip: C-shaped clip 25mm inner diameter, 3mm wall, 15mm tall — a simple ring with a 10mm-wide gap opening.
+94. A simple coin sorter funnel (one size): round funnel 100mm top diameter, 25mm spout, 3mm walls, 60mm tall.
+95. A simple wall plug: flat rounded-corner rectangle 80mm × 45mm × 12mm with two round socket holes and one earth slot.
+96. A simple whiteboard eraser body: rectangular block 110mm × 50mm × 25mm with slightly rounded side edges.
+97. A simple door handle lever: horizontal cylinder handle 140mm × 20mm diameter, with a square mounting block 40mm × 40mm × 30mm at one end.
+98. A simple plastic card holder: flat frame 90mm × 60mm × 5mm with a 3mm lip around the perimeter and a slot 20mm wide at the top for inserting cards.
+99. A simple egg timer base: wide flat disc 100mm diameter and 8mm tall, with a narrow cylinder neck 15mm diameter and 20mm tall in the centre for supporting a glass globe.
+100. A simple bathroom towel ring: torus 80mm major radius and 8mm minor radius, mounted on a flat wall plate 80mm × 40mm × 10mm from one side.

--- a/workbench/categories/08-mechanical-components.md
+++ b/workbench/categories/08-mechanical-components.md
@@ -1,0 +1,112 @@
+---
+rank: 8
+name: Mechanical Components
+complexity: 7
+description: >
+  Functional mechanical parts such as fasteners, brackets, gears, shafts,
+  couplings, and structural components. Parts should reflect real engineering
+  geometry — correct proportions and features, even if thread detail is omitted.
+---
+
+## Examples
+
+1. An M8 hex head bolt: hexagonal head 13mm across flats and 6mm tall, with a cylinder shank 8mm diameter and 50mm long below the head.
+2. An M10 hex nut: hexagonal prism 17mm across flats and 8mm tall with a 10mm cylindrical bore through the centre.
+3. A standard flat washer for M8 bolts: disc 24mm outer diameter and 1.5mm thick with an 8.4mm centre hole.
+4. A large fender washer: disc 44mm outer diameter and 2mm thick with a 10mm centre hole.
+5. A spring lock washer for M6: split ring 12mm outer diameter, 6mm inner diameter, 1.5mm thick with a 1-turn helix.
+6. An M6 countersunk (flat head) screw: countersunk head 12mm top diameter tapering to 6mm at the shank, 4mm head height, 30mm shank.
+7. An M5 pan head screw: cylindrical head 10mm diameter and 3.5mm tall with a Phillips cross slot, 20mm shank.
+8. An M3 cap head (socket head) screw: hexagonal socket head 5.5mm diameter and 3mm tall, 16mm shank.
+9. A carriage bolt: round domed head 20mm diameter and 6mm tall, square anti-rotation neck 10mm × 10mm × 5mm below the head, then 8mm cylinder shank 50mm long.
+10. A wing nut for M8: hexagonal M8 nut with two flat wings 40mm wide and 15mm tall.
+11. A T-nut for T-slots: flat T-shaped head 20mm wide × 6mm tall with a cylinder shank 10mm diameter and 12mm long below, and a 6mm bore through the full height.
+12. A simple spur gear: 20-tooth gear, module 2, 40mm pitch diameter, 15mm tall, with a 10mm centre bore.
+13. A gear rack: flat bar 120mm × 20mm × 8mm with 15 evenly spaced rectangular teeth 4mm wide and 3mm tall on the top face.
+14. A simple bevel gear blank: truncated cone 60mm base diameter and 40mm top diameter, 20mm tall, with 15mm centre bore — the gear tooth region is represented as the cone surface.
+15. A worm gear screw blank: cylinder 20mm diameter and 60mm tall with a continuous single-lead thread approximated by a helical rib.
+16. A stepped shaft: three-section cylinder — 30mm diameter × 40mm, then 20mm diameter × 60mm, then 15mm diameter × 30mm, all coaxial.
+17. A shaft with a keyway: cylinder 25mm diameter and 100mm long with a rectangular keyway slot 8mm wide and 4mm deep along the full length.
+18. A shaft with a snap ring groove: cylinder 20mm diameter and 80mm long with a 2mm-wide and 1.5mm-deep groove circumferential groove near one end.
+19. A double-ended stud: threaded studs approximated — cylinder 12mm diameter and 80mm long with a 20mm hex flat section in the middle.
+20. A turnbuckle body: cylinder 20mm diameter and 60mm long with a slot through the middle (a 10mm × 10mm × 60mm rectangular slot through the side) creating a frame.
+21. An L-shaped steel bracket (gusset bracket): two flat plates 80mm × 40mm × 5mm joined at 90 degrees with a triangular gusset plate 30mm × 30mm × 5mm at the inside corner.
+22. A flat bar clamp jaw: rectangular block 100mm × 40mm × 15mm with two 12mm through-holes and a 15mm-deep slot cut from one face.
+23. A hinge leaf (one half of a butt hinge): flat plate 80mm × 40mm × 3mm with three 4mm mounting holes and a 7mm-diameter barrel cylinder 40mm long along one edge.
+24. A simple clevis bracket: U-shaped bracket, overall 60mm wide, 40mm deep, 6mm thick walls, with an 8mm through-hole through both arms.
+25. A simple pillow block bearing housing exterior: rectangular block 80mm × 50mm × 50mm with a 30mm cylindrical through-bore and two 8mm mounting holes through the base flange.
+26. A coupling sleeve: short hollow cylinder 50mm outer diameter, 30mm inner diameter, 40mm long, with two radial 6mm set-screw holes at 90 degrees.
+27. A simple crank arm: flat rectangular arm 100mm × 25mm × 10mm with a 20mm hole at one end and a 10mm hole at the other.
+28. A connecting rod big end cap: semicircular shape 60mm bolt-circle diameter, 15mm thick, with two 8mm through-holes.
+29. A simple flange coupling: disc 100mm diameter and 20mm thick with a 25mm central bore, four 8mm bolt holes on a 70mm PCD, and a 5mm × 5mm keyway in the bore.
+30. A simple V-belt pulley: cylinder 100mm outer diameter and 30mm wide, with a V-groove profile around the circumference (trapezoidal groove 15mm deep at centre), central 20mm bore.
+31. A chain sprocket blank: disc 80mm diameter and 12mm thick with a 15mm centre bore and eight 10mm tooth stubs evenly spaced around the rim.
+32. A simple jaw coupling spider element: hexagonal cross-section 60mm across flats and 30mm thick, with a 20mm centre bore — the rubber spider in a jaw coupling.
+33. A shaft collar: cylinder 40mm outer diameter and 15mm wide, with 20mm bore, and a 4mm-wide split slot cut along the full length.
+34. A simple taper bush: truncated cone 60mm large end and 50mm small end, 30mm long, with 20mm bore and a 5mm keyway.
+35. A simple plummer block housing (exterior only): rectangular block 120mm × 60mm × 60mm with a 40mm semi-circular bore on the top face and four 10mm mounting holes through the base.
+36. A simple spanner/wrench: flat body 200mm × 30mm × 8mm with a hexagonal opening 17mm across flats at one end and a 13mm opening at the other.
+37. A simple ratchet socket (exterior): hexagonal outer profile 22mm across flats and 30mm tall, with a square 12.7mm drive socket on one end and a 12mm hexagonal bore on the other.
+38. A simple pliers handle (one side): ergonomic flat handle 150mm × 30mm × 8mm, wider at the grip and narrowing toward the hinge pivot.
+39. A simple compression spring coil: helix made from a 3mm-diameter wire, 20mm coil diameter, 8 turns, 40mm free length.
+40. A simple extension spring hook end: cylinder 20mm coil diameter from 2mm wire, 6 turns, with a circular hook loop 15mm diameter on each end.
+41. A simple torsion spring: coil of 2mm wire 20mm diameter, 4 turns, with two straight tangent legs 30mm long at the ends.
+42. A simple disc spring (Belleville washer): conical washer 60mm outer diameter and 30mm inner diameter, 3mm thick, with a 10-degree conical angle.
+43. A simple ball and detent plunger housing: cylinder 20mm outer diameter and 40mm long, with a 6mm ball-end bore at one end and an M20 thread approximation at the other end.
+44. A simple latch hook: flat arm 80mm × 10mm × 6mm bent at 90 degrees at the end to form a 15mm hook.
+45. A simple cam follower body: cylinder 30mm diameter and 20mm tall, with a 10mm axle bore and a slightly eccentric profile.
+46. A simple rack and pinion gear set (rack portion): bar 150mm × 20mm × 10mm with 18 teeth 4mm wide and 3mm tall along the top edge.
+47. A simple worm wheel blank: disc 80mm diameter and 20mm thick with an hourglass (concave) profile on the outer rim to mesh with a worm, centre bore 20mm.
+48. A simple Oldham coupling disc (middle element): flat disc 60mm diameter and 10mm thick with two rectangular tenons 20mm × 6mm × 5mm on opposite faces, rotated 90 degrees from each other.
+49. A simple universal joint yoke: U-shaped fork 50mm wide, arms 50mm long and 8mm thick, with 10mm through-holes in both arms, and a square shank 20mm × 20mm × 40mm.
+50. A simple eccentric (shaft eccentric): cylinder 50mm outer diameter and 20mm thick, with a 20mm bore offset 10mm from the centre.
+51. A simple mounting plate with a four-hole NEMA 17 stepper motor pattern: 47mm × 47mm square plate 5mm thick, four M3 holes on 31mm square PCD, central 22mm clearance hole.
+52. A simple motor mounting bracket for a 37mm gearbox motor: U-bracket 50mm wide, arms 30mm tall and 4mm thick, with 37mm-diameter arc for the motor, and two 3mm mounting holes in each arm.
+53. A simple tension rod end (fork end): rectangular block 30mm × 20mm × 10mm with a 10mm fork slot and 8mm pin hole.
+54. A simple rod clevis with a pin: clevis body 40mm × 20mm × 12mm, arms with 8mm pin holes, threaded rod end approximated as a short cylinder.
+55. A simple taper lock bushing: cylinder 60mm outer and 40mm inner diameter, split with a longitudinal slot, with two M8 bolt holes through the split flanges.
+56. A simple timing belt pulley: cylinder 30mm pitch diameter and 20mm wide, with 15 evenly spaced trapezoidal teeth (2mm pitch), central 10mm bore, and two flanges 40mm diameter and 2mm thick on each side.
+57. A simple ball screw nut housing exterior: cylinder 60mm outer diameter and 40mm long with four M6 flange holes on a 50mm PCD.
+58. A simple pneumatic cylinder body: tube 60mm outer and 50mm inner diameter, 100mm long, with two threaded end cap positions shown as flanges, and one port boss on the side.
+59. A simple toggle clamp base plate: 120mm × 60mm × 8mm plate with four M5 holes for mounting and two pivot pin holes 6mm diameter at each end.
+60. A simple quick-release pin: cylinder 10mm diameter and 60mm long with a spherical detent 3mm at one end and a ring pull 20mm outer diameter on the other.
+61. A simple chain link (one link): oval ring 40mm × 20mm inner, 5mm wire diameter.
+62. A simple bicycle chain link (simplified): two flat plates 12mm × 20mm × 1.5mm connected by two cylinder pins 4mm diameter and 4mm long.
+63. A simple hydraulic fitting (straight union): hex body 20mm across flats and 25mm long with a 10mm bore and short pipe stubs 12mm outer diameter on each end.
+64. A simple compression fitting olive: small truncated cone 14mm outer and 10mm inner diameter, 6mm long.
+65. A simple drill chuck key: flat body 80mm × 15mm × 6mm with a pinion cylinder 8mm diameter and 10mm long at one end, and a handle T-shape 40mm × 10mm.
+66. A simple adjustable spanner body (without the jaw): flat body 180mm × 35mm × 10mm, with a fixed jaw 15mm wide and 20mm deep at the head end.
+67. A simple C-clamp body: C-shaped flat arm 5mm thick, opening 60mm wide and 60mm deep, with a threaded hole 10mm at the end of one arm for the clamping screw.
+68. A simple vice jaw (smooth): flat rectangular jaw 120mm × 60mm × 20mm.
+69. A simple drive shaft coupling: two-piece sleeve — outer cylinder 50mm diameter and 60mm long, bored to receive two 20mm shafts from each end.
+70. A simple cam lever: flat body 100mm × 20mm × 8mm with a circular cam lobe 30mm diameter at one end (eccentric boss) and a handle grip at the other.
+71. A simple ratchet pawl: flat body 40mm × 10mm × 5mm with a pointed tip and a 4mm pivot hole.
+72. A simple snap fit clip: flat arm 30mm × 6mm × 2mm with a 3mm-tall bump at the tip and a mounting hole at the base.
+73. A simple split pin (cotter pin): U-shaped hairpin 4mm wire diameter and 50mm long, with a round head at the closed end.
+74. A simple shoulder bolt: a cylinder 10mm diameter shoulder 20mm long, topped by a smaller 8mm threaded section, capped with a hex socket head.
+75. A simple dowel pin: precision cylinder 6mm diameter and 40mm long, with chamfered ends.
+76. A simple threaded rod section: cylinder 12mm diameter and 100mm long (smooth — thread detail omitted for simplicity).
+77. A simple pipe nipple: short pipe 25mm outer, 19mm inner, 100mm long with two hex flat sections on the outer surface near each end.
+78. A simple ball valve body: rectangular block 60mm × 40mm × 40mm with a 20mm through-bore, two port stubs 25mm outer diameter on each side, and a top handle mount stub.
+79. A simple pressure gauge body exterior: disc 60mm diameter and 30mm thick with a flat front face, a curved back, and a 9mm threaded port stub 20mm long.
+80. A simple bracket for a linear rail: flat plate 60mm × 40mm × 6mm with a 20mm wide and 8mm deep rail channel milled into one face, and four 4mm mounting holes.
+81. A simple set screw (grub screw): cylinder 6mm diameter and 8mm long with a hex socket 3mm across flats in one end.
+82. A simple eye bolt: cylinder 10mm shank and 50mm long, topped by a circular ring (eye) 25mm outer diameter and 5mm wire diameter.
+83. A simple anchor nut (K-nut): small rectangular plate 30mm × 12mm × 4mm with a 6mm nut cage and two 4mm wing holes.
+84. A simple retaining ring (circlip): flat incomplete-circle ring 40mm outer diameter, 1.5mm thick, 1.5mm gap, 4mm lugs with 3mm pin holes.
+85. A simple bevel gear coupling cone: truncated cone 80mm base and 60mm top, 30mm tall, with 20mm bore and a 45-degree bevel on one face.
+86. A simple mechanical advantage lever arm: rectangular bar 200mm × 15mm × 10mm with a 10mm pivot hole 20mm from one end and a 8mm load hole at the far end.
+87. A simple rope cleat: diamond-shaped base plate 120mm × 50mm × 8mm with two raised horn cylinders 12mm diameter and 20mm tall, angled 30 degrees outward from the centreline.
+88. A simple flat key: rectangular bar 10mm × 6mm × 40mm with chamfered ends.
+89. A simple woodruff key: half-disc 16mm diameter and 4mm wide.
+90. A simple castellated bolt head: hexagonal prism 17mm across flats and 15mm tall with six rectangular slots 4mm wide and 8mm deep cut evenly around the top.
+91. A simple turnbuckle barrel: cylinder 25mm outer and 10mm inner diameter, 60mm long, with a 10mm slot on each end extending 20mm in.
+92. A simple star washer (external toothed): flat ring 20mm outer and 10mm inner diameter, 1.5mm thick, with 12 triangular serrations around the outer edge.
+93. A simple tension bracket: flat plate 100mm × 40mm × 6mm with a 90-degree bend 40mm from one end, creating an angled elbow.
+94. A simple flanged nut: hexagonal nut 17mm across flats and 8mm tall with a wide flange disc 25mm diameter and 3mm thick extending from the bearing face.
+95. A simple double-shear clevis pin: cylinder 10mm diameter and 60mm long, with two 2mm-wide grooves for retaining clips, 5mm from each end.
+96. A simple jam nut (thin nut): hexagonal prism 13mm across flats and 4mm tall with an 8mm bore.
+97. A simple bearing preload shim: thin ring 40mm outer diameter and 30mm inner, 0.5mm thick.
+98. A simple crankpin: short cylinder 20mm diameter and 30mm long, with a 5mm-diameter oil hole drilled radially through its length.
+99. A simple tension tie rod with clevis ends: cylinder 16mm diameter and 200mm long, with U-shaped fork ends 30mm wide and 10mm hole each.
+100. A simple hub flange for a wheel: disc 120mm diameter and 20mm thick with a 25mm centre bore, five 12mm stud holes on a 80mm PCD, and an inner ring feature 60mm diameter and 5mm proud.

--- a/workbench/categories/09-electronic-components.md
+++ b/workbench/categories/09-electronic-components.md
@@ -1,0 +1,112 @@
+---
+rank: 9
+name: Electronic Components
+complexity: 8
+description: >
+  3D-printable parts for electronics projects: PCB standoffs, cable management,
+  heat sinks, panel cutouts, connector mounts, and component holders.
+  Parts must reflect real-world dimensions used in electronics.
+---
+
+## Examples
+
+1. A PCB standoff: hexagonal outer body 8mm across flats and 12mm tall, M3 bore through the full height.
+2. A PCB standoff with male thread: hexagonal 6mm across flats and 10mm tall, M3 female bore 8mm deep on one end, M3 male stud 5mm long on the other.
+3. An M3 threaded insert pocket boss: cylinder 8mm outer diameter and 8mm tall with a 5mm bore — the correct pocket diameter for an M3 heat-set insert.
+4. A PCB mounting pillar: cylinder 10mm outer diameter and 20mm tall with a 3mm bore through the centre.
+5. A simple PCB support foot: flat disc 15mm diameter and 3mm thick with a cylinder 4mm diameter and 15mm tall rising from the centre.
+6. A cable clip for 3mm cable: C-shaped clip, 3mm inner radius, 2mm wall, 10mm tall, with a 5mm-wide gap opening and two 3mm mounting-hole tabs.
+7. A cable clip for 6mm conduit: C-shaped clip, 6mm inner radius, 2.5mm wall, 12mm tall, mounting flange 20mm × 8mm × 3mm.
+8. A cable saddle for 4mm cable bundles: flat base 30mm × 10mm × 3mm with a U-shaped saddle 8mm inner diameter rising 12mm tall.
+9. A cable tie mount: flat base 25mm × 20mm × 3mm with two cable tie slots 3mm × 1.5mm through the base, 5mm apart.
+10. A self-adhesive cable clamp footprint (no adhesive): flat base 25mm × 20mm × 3mm with a cable tie loop forming a 6mm-high ring above the base.
+11. A simple panel-mount LED holder: cylinder 8mm outer diameter and 12mm tall with a 5mm bore for a standard 5mm LED, and a snap-rim 1mm tall at the front.
+12. A flush-mount panel LED housing: cylinder 12mm outer diameter and 10mm tall with a 5mm bore, and a 12mm diameter × 2mm flange at the front.
+13. A panel-mount momentary button housing: cylinder 16mm outer and 12mm tall with a smooth bore for a 16mm push button.
+14. A micro-switch mounting bracket: flat plate 30mm × 20mm × 3mm with two M2 holes 20mm apart and a 5mm operation-arm clearance slot.
+15. A simple toggle switch panel cutout frame: flat plate 40mm × 40mm × 3mm with a 13mm × 6mm rectangular cutout for a standard mini toggle switch.
+16. A simple rocker switch cutout frame: flat plate 50mm × 40mm × 3mm with a 21mm × 15mm rectangular cutout for a standard rocker switch.
+17. A USB Type-A panel mount adapter frame: flat plate 35mm × 25mm × 3mm with a 14mm × 7mm rectangular cutout with 1mm chamfered corners.
+18. A USB Type-C panel mount housing: flat plate 30mm × 20mm × 3mm with a 10mm × 4mm rectangular cutout.
+19. A micro-USB panel mount frame: flat plate 30mm × 20mm × 3mm with a 9mm × 5mm rectangular cutout.
+20. A DC barrel jack panel mount housing: cylinder 11mm outer and 5.5mm bore, 12mm tall, with a 25mm × 15mm × 3mm flange at the rear.
+21. A DB9 connector panel cutout frame: flat plate 50mm × 25mm × 3mm with a 30mm × 12mm rectangular cutout with chamfered corners, and two M3 mounting holes on 33.3mm centres.
+22. A DB15 (VGA) panel cutout frame: flat plate 65mm × 30mm × 3mm with a 44mm × 15mm trapezoidal cutout and two M3 holes on 47mm centres.
+23. A simple RJ45 (Ethernet) panel cutout: flat plate 40mm × 20mm × 3mm with a 16mm × 14mm rectangular cutout.
+24. A 3.5mm audio jack panel cutout: flat plate 25mm × 15mm × 3mm with an 8mm circular cutout.
+25. A panel-mount fuse holder housing: cylinder 22mm outer and 5mm tall flange, with a 20mm bore and 50mm total length.
+26. A simple DIN rail clip (symmetric): flat plate 35mm × 30mm × 3mm with two rails — top fixed rail 12mm wide and bottom spring clip rail 12mm wide — forming a C-channel to clip onto 35mm DIN rail.
+27. A DIN rail end stop: flat plate 35mm × 8mm × 3mm with a locking tab and a 4mm hole.
+28. A simple hat-type DIN rail bracket: T-shaped bracket fitting the 35mm top-hat rail profile, 15mm wide mounting wing.
+29. A raspberry Pi Zero W mounting plate: flat plate 65mm × 30mm × 2mm with four M2.5 holes on 58mm × 23mm centres (standard Pi Zero mounting pattern).
+30. A Raspberry Pi 4 model B mounting plate: flat plate 85mm × 56mm × 2mm with four M2.5 holes matching the Pi 4 mounting pattern — 58mm × 49mm, 3.5mm from each edge.
+31. A Raspberry Pi 5 mounting plate: flat plate 85mm × 56mm × 2mm with four M2.5 standoff holes at standard positions (Pi 5 is the same footprint as Pi 4).
+32. An Arduino Uno mounting plate: flat plate 68mm × 53mm × 2mm with four M3 holes at standard Uno mounting positions.
+33. An Arduino Nano mounting adapter: flat plate 45mm × 18mm × 3mm with two rows of four 1mm pinholes for the Nano headers and two M3 mounting holes.
+34. An ESP32 DevKit V1 mounting plate: flat plate 55mm × 28mm × 3mm with two M2.5 holes and two rows of 19 pinhole positions 2.54mm apart.
+35. A Wemos D1 Mini mounting bracket: flat plate 35mm × 26mm × 3mm with two M3 holes and an outline for the D1 Mini footprint.
+36. A simple LCD display bezel for a 16×2 character LCD: flat plate 83mm × 36mm × 3mm with a rectangular cutout 72mm × 20mm for the display area.
+37. A simple 0.96-inch OLED display bezel: flat plate 30mm × 20mm × 3mm with a 26mm × 14mm rectangular cutout.
+38. A 1.3-inch OLED display bezel: flat plate 36mm × 26mm × 3mm with a 30mm × 20mm cutout.
+39. A 2.8-inch TFT LCD bezel: flat plate 75mm × 55mm × 3mm with a 55mm × 40mm rectangular cutout for the active area.
+40. A simple 7-segment LED display holder: flat plate 32mm × 20mm × 3mm with a 25mm × 14mm rectangular cutout.
+41. A heatsink fin block: rectangular block 50mm × 50mm × 5mm base with ten fins 50mm × 30mm × 2mm spaced 4mm apart on the top face.
+42. A heatsink for a TO-220 transistor: flat base 30mm × 25mm × 3mm with five fins 25mm × 15mm × 1.5mm and a central M3 mounting hole.
+43. A heatsink for a Raspberry Pi CPU: 15mm × 15mm × 3mm base with a 3×3 grid of 1.5mm-thick fins 15mm × 8mm tall.
+44. A simple fan guard: flat ring 80mm outer and 70mm inner diameter, 3mm thick, with a 3×3 grid of 5mm holes in the centre and four corner M4 holes on 80mm square pattern.
+45. A 40mm fan mount adapter: 40mm × 40mm frame, 3mm thick, with four M3 holes on standard 32mm fan mount centres and a 36mm circular opening.
+46. An 80mm fan guard: 80mm × 80mm frame 3mm thick, central 72mm opening, four M4 holes on 71.5mm square mount pattern.
+47. A simple battery holder for two AA batteries: rectangular box 60mm × 30mm × 30mm with two 14.5mm-diameter × 52mm-long battery bays side by side, open at the end for insertion.
+48. A 18650 single cell battery holder: cylinder 19mm inner diameter and 70mm long, with a flat base and a contact spring stub.
+49. A coin cell (CR2032) holder: cylinder 22mm inner diameter and 5mm deep, with a flat base and a 3mm × 1mm slot for a spring contact.
+50. A simple 9V battery clip mount: flat base 30mm × 30mm × 3mm with two conical snap features for a 9V battery connector.
+51. A panel-mount potentiometer housing: cylinder 9mm outer and 20mm tall with a 7mm bore, and a 25mm × 15mm × 3mm mounting flange at the rear.
+52. A rotary encoder knob: cylinder 20mm outer diameter and 15mm tall, with a flat on one side inside a 6mm bore (D-shaft flat).
+53. A simple shaft encoder disc: flat disc 60mm diameter and 2mm thick with 24 equally spaced 3mm holes on a 50mm circle, and a 6mm centre hole.
+54. A simple reed switch holder: rectangular channel 20mm × 8mm × 5mm, open at one end, with an integrated flat magnet pocket on the outside.
+55. A simple photoresistor mounting cap: cylinder 8mm outer and 6mm tall with a 5mm bore and a 1mm-wide radial slot for wire routing.
+56. A simple infrared LED collimator: cylinder 8mm outer and 15mm tall with a 5mm bore tapering to 3mm, for collimating an IR LED.
+57. A simple motion sensor (PIR) dome housing: hemisphere 30mm diameter with a flat mounting plate 40mm × 40mm × 3mm and a 24mm circular cutout.
+58. A simple ultrasonic sensor mount (HC-SR04): flat plate 45mm × 20mm × 3mm with two 16mm diameter holes 26mm apart for the transducer cans, and two M3 mounting holes.
+59. A simple BMP280 breakout board bracket: flat plate 15mm × 12mm × 3mm with two M2 holes matching the module, and a 5mm ventilation hole for the sensor.
+60. A simple LiPo battery holder strap: flat band 80mm × 12mm × 2mm with two slots 5mm × 2mm for a zip tie and two M3 screw holes.
+61. A simple step-down converter (buck converter) mounting tray: rectangular tray 48mm × 26mm × 4mm walls, 3mm floor, with four M2 corner holes.
+62. A simple Raspberry Pi camera module v3 mount: flat plate 25mm × 24mm × 3mm with four M2 holes on 17mm × 12.5mm centres and a 7.8mm × 7.8mm lens cutout.
+63. A simple cooling duct: rectangular duct 60mm × 40mm cross-section and 80mm long, 3mm wall, routing airflow from a fan to a component.
+64. A simple Peltier module mounting plate: flat plate 50mm × 50mm × 5mm with four M3 corner holes and a central clearance hole 40mm.
+65. A simple BNC connector panel mount frame: flat plate 30mm × 20mm × 3mm with a 15mm circular cutout.
+66. A simple SMA connector panel mount plate: flat plate 25mm × 25mm × 3mm with a 7mm circular cutout and four M2 holes.
+67. A simple PCB test point probe holder: cylinder 8mm outer and 30mm long with a 4mm bore for a test probe tip.
+68. A simple hall-effect sensor housing: cylinder 8mm outer and 20mm long, 5mm bore, with a 15mm × 10mm × 3mm mounting tab.
+69. A simple stepper motor (NEMA 17) mount plate: square plate 47mm × 47mm × 4mm with four M3 holes on a 31mm square pattern and a 22mm central clearance hole.
+70. A simple NEMA 23 stepper motor mount plate: square plate 57mm × 57mm × 5mm with four M5 holes on a 47.1mm diagonal pattern and a 38.1mm central clearance hole.
+71. A simple servo motor bracket (SG90 servo): C-shaped bracket — top plate 23mm × 32mm, side walls 23mm × 22mm, bottom slot for servo body, two M2 holes in each side wall.
+72. A simple servo horn round type: disc 20mm diameter and 3mm thick with eight evenly spaced 2mm holes at 8mm radius and a central 3.5mm splined hole.
+73. A simple cable strain relief clip: flat body 30mm × 20mm × 4mm, split in half — two half-cylinders 8mm inner diameter that clamp together.
+74. A simple PCB edge connector guide: flat L-shaped rail 80mm × 8mm × 6mm with a 1.6mm slot along the inner face to guide a PCB edge.
+75. A simple component tray for small parts: rectangular box 100mm × 80mm × 20mm, 2mm walls, open top, divided into a 3×2 grid of six equal compartments by 2mm interior walls.
+76. A simple Raspberry Pi 4 GPIO breakout mount: flat plate 58mm × 30mm × 3mm with a 40-pin (2×20) grid of 2.54mm-spaced 2mm holes.
+77. A simple terminal block housing: rectangular box 30mm × 20mm × 25mm with wire entry holes 4mm diameter on one face and two screw access holes on the top.
+78. A simple strain gauge load cell mounting plate: flat plate 80mm × 40mm × 8mm with four M4 holes at each end for attaching the load cell.
+79. A simple control board DIN rail mounting clip: flat plate 80mm × 30mm × 3mm with two DIN rail clips on the back and four M3 holes on the front for a PCB.
+80. A simple heat shrink label holder: flat rectangular clip 30mm × 10mm × 2mm with an open C-slot for a wire bundle to pass through.
+81. A simple junction box lid: flat plate 100mm × 80mm × 3mm with a 5mm lip around the perimeter and four M3 corner holes.
+82. A simple relay module mounting plate: flat plate 80mm × 50mm × 3mm with four M3 holes at standard relay mounting positions.
+83. A simple optical fibre strain relief ferrule: cylinder 8mm outer and 4mm bore, 20mm long, with a hex flat section 12mm long for gripping.
+84. A simple I2C OLED cable management clip: small clip 30mm × 8mm × 4mm designed to route and secure a flat FFC cable along a surface.
+85. A simple antenna mount: flat plate 30mm × 30mm × 3mm with a central 7mm hole for an SMA bulkhead and four 3mm corner holes.
+86. A simple LCD backlight power connector housing: small box 15mm × 8mm × 6mm with two wire entry holes on one end and a connector retaining tab.
+87. A simple reed relay socket: rectangular holder 20mm × 8mm × 10mm with a 5mm × 15mm × 4mm slot for inserting a glass reed relay, and two wire guide holes.
+88. A simple custom button cap for 6mm square tact switch: small cylinder 8mm outer and 8mm tall with a flat top and a 6.5mm × 6.5mm square recess on the bottom.
+89. A simple ESP8266 NodeMCU mounting adapter: flat plate 30mm × 58mm × 3mm with four 2mm pin guide holes at each header end and two M3 mounting holes.
+90. A simple custom GPIO label plate: flat plate 58mm × 10mm × 2mm with 40 raised rectangular tabs 1.5mm × 4mm × 1mm, spaced 2.54mm apart on two rows — a physical pin label strip.
+91. A simple wire loom bracket: arc-shaped bracket 40mm inner radius, 5mm thick, 20mm wide, with two M3 holes for wall mounting, forming a curved retaining channel.
+92. A simple cable raceway clip: flat plate 25mm × 20mm × 3mm with a rectangular channel 15mm × 10mm on one face to clip onto a cable raceway.
+93. A simple 5V regulator (78L05) through-hole PCB standoff: cylinder 6mm diameter and 8mm tall with a 3mm bore.
+94. A simple heat paste applicator spreader: flat blade 60mm × 20mm × 1mm with a handle 60mm × 15mm × 4mm, like a tiny putty knife.
+95. A simple capacitor bracket: flat plate 30mm × 20mm × 3mm with a semicircular saddle 10mm inner diameter and 10mm tall for holding a large electrolytic capacitor upright.
+96. A simple Raspberry Pi display HAT standoff plate: flat plate 85mm × 56mm × 3mm with four M2.5 holes matching Pi4 mounting, and six additional M2.5 holes for the HAT PCB.
+97. A simple ESP32-CAM camera cover plate: flat plate 40mm × 27mm × 2mm with a circular lens cutout 10mm diameter and two M2 mounting holes.
+98. A simple terminal screwpost: cylinder 12mm outer diameter and 20mm tall with a 3.5mm screw bore from the top and a wire hole 2mm entering from the side.
+99. A simple clip-on cable organiser ring: torus 30mm outer and 20mm inner diameter, 8mm thick, with a 4mm-wide opening slot cut through one side — clips around a bundle of cables.
+100. A simple PWM servo controller board tray: flat plate 80mm × 50mm × 3mm with four M2.5 holes at corner positions for an Adafruit PCA9685 16-channel board, and two cable routing slots on one side.

--- a/workbench/categories/10-enclosures.md
+++ b/workbench/categories/10-enclosures.md
@@ -1,0 +1,112 @@
+---
+rank: 10
+name: Generic Enclosures
+complexity: 9
+description: >
+  Generic project enclosures, boxes, and housings. Combines all previously
+  learned operations: shelling, Boolean cutouts for ports, mounting features,
+  ventilation patterns, and lid/cover assemblies. 5% of examples include color.
+---
+
+## Examples
+
+1. A simple two-part snap-fit project box: bottom half 100mm × 60mm × 40mm with 2mm walls and a 2mm snap lip, top lid 100mm × 60mm × 12mm with a matching snap groove.
+2. A rectangular electronics enclosure: 120mm × 80mm × 50mm, 3mm walls, open top, four M3 corner boss standoffs 5mm diameter and 8mm tall inside.
+3. A simple project box with a removable lid: box 150mm × 100mm × 60mm, 3mm walls, with four M3 screw recesses on the side flanges for lid attachment.
+4. A small waterproof enclosure body: 80mm × 50mm × 35mm, 4mm walls, with a 2mm-wide O-ring groove around the top opening rim.
+5. A desktop project box with a sloped front panel: 160mm × 100mm × 80mm body with the front face angled at 20 degrees for a console look.
+6. A wall-mount junction box: 100mm × 80mm × 40mm, 3mm walls, with four 5mm wall-mount keyhole slots on the back face.
+7. A small handheld controller housing: 140mm × 70mm × 35mm, ergonomically rounded with 4mm walls and a smooth grip profile.
+8. A DIN-rail-mounted enclosure body: 90mm × 60mm × 58mm with a DIN rail clip channel on the back — standard 35mm hat-rail slot.
+9. A small 3D-printed relay box: 80mm × 60mm × 40mm with a 3mm wall and two 5mm holes on one face for relay screw terminals.
+10. A simple two-part hinge-lid box: 120mm × 80mm × 60mm box with an integrated living hinge 3mm wide along one 120mm edge, and a lid 120mm × 80mm × 20mm.
+11. A ventilated electronics box: 150mm × 100mm × 60mm with 3mm walls, a 3×5 grid of 10mm circular ventilation holes on the top face, and four internal M3 standoffs.
+12. A panel-mount instrument case body: 160mm × 100mm × 80mm with an angled instrument face 20 degrees and a 150mm × 90mm rectangular cutout on the face.
+13. A small audio amplifier enclosure: 200mm × 120mm × 60mm, 3mm walls, with a 40mm circular speaker cutout on the front face and four M3 mounting holes.
+14. A Raspberry Pi 4 enclosure body (bottom half): 85mm × 56mm outer footprint with 3mm walls, 30mm tall, four M2.5 standoffs at standard Pi mounting positions.
+15. An Arduino Uno enclosure (bottom tray): 90mm × 70mm × 25mm outer, 3mm walls, four M3 standoffs for the Uno PCB.
+16. A small IoT sensor enclosure: 60mm × 40mm × 25mm, 2mm walls, snap lid, 5mm vent hole on one face, 5mm cable exit hole on another.
+17. A two-part round enclosure: cylindrical box 80mm outer diameter and 60mm tall, 3mm walls, split horizontally at the equator with a snap groove.
+18. A waterproof enclosure lid with an O-ring channel: flat plate 120mm × 80mm × 10mm with a 2mm-wide, 1.5mm-deep rectangular O-ring groove 5mm from the edge, and four M4 through-holes at corners.
+19. A simple battery box enclosure: 80mm × 40mm × 30mm, holding two AA batteries side by side, sliding lid on one end, spring contact recesses in the floor.
+20. A simple Raspberry Pi Zero enclosure: 68mm × 32mm × 18mm, 2mm walls, with cutouts for the micro-USB port (10mm × 5mm), mini HDMI (12mm × 5mm), and camera ribbon (22mm × 3mm) slots.
+21. An outdoor IP65 enclosure body: 150mm × 100mm × 80mm, 5mm walls, with a 3mm-wide labyrinthine sealing channel around the opening and four M5 lid bolt holes.
+22. A small transformer enclosure: 100mm × 80mm × 70mm box with a 3mm wall, four ventilation slots 40mm × 3mm on each side, and a 15mm cable gland boss.
+23. A cable splitter box: 80mm × 60mm × 40mm with three 15mm circular cable entry holes — one on the left side and two on the right — and M3 standoffs for a PCB inside.
+24. A simple power strip enclosure body: 300mm × 60mm × 40mm with four 40mm circular socket cutouts on the top face, evenly spaced, and a cable entry 15mm on one end.
+25. A desktop USB hub box: 120mm × 60mm × 25mm with four 15mm × 8mm USB-A port cutouts on the front face and a micro-USB power port cutout on the back.
+26. A small GPS tracker enclosure: 70mm × 45mm × 20mm with 2mm walls, SMA antenna port 7mm hole on top, USB port on one end, and four M2 through-holes for a PCB.
+27. A simple 3D-printed Faraday cage box: 100mm × 80mm × 60mm with 3mm walls, including a 5mm mounting flange with M3 holes around the top perimeter for a metal lid.
+28. A simple rack-mount panel blank (1U): 482mm × 44mm × 2mm flat panel with four M6 mounting holes on 465mm centres.
+29. A simple rack-mount enclosure body (1U, shallow): 480mm × 200mm × 40mm with 3mm walls, front panel cutout 465mm × 36mm, and a cable pass-through 50mm × 20mm on the back.
+30. A simple 3D-printed case for a NodeMCU: 50mm × 30mm × 25mm, 2mm walls, micro-USB cutout on one end, two rows of header access slots on the long sides.
+31. A simple electronics project box with a transparent lid placeholder: 100mm × 80mm × 40mm box, 3mm walls, top face open (no lid on this part).
+32. A simple electrical conduit junction box: cube 100mm × 100mm × 100mm, 3mm walls, four circular 20mm conduit entry knockouts on the sides.
+33. A simple signal relay enclosure with terminal blocks on one face: 100mm × 60mm × 50mm box, 3mm walls, four 8mm terminal block entry holes on one face.
+34. A simple enclosure for a 12V power supply module: 120mm × 80mm × 50mm, 3mm walls, ventilation slots on both sides (three slots each, 50mm × 4mm), and AC/DC connector cutouts on each end.
+35. A simple 3D-printed enclosure for a capacitive touch sensor pad: thin box 80mm × 60mm × 8mm with a smooth 2mm-thick transparent-area placeholder on top and a 5mm cable exit hole.
+36. A small plastic project box with front panel controls: 160mm × 100mm × 80mm, 3mm walls, front face with a 20mm encoder hole, two 16mm button holes, and a 100mm × 60mm LCD cutout.
+37. A simple flip-top box: 100mm × 70mm × 60mm base with 3mm walls and a flat top lid 100mm × 70mm × 15mm hinged along one edge with an integrated flexible hinge tab.
+38. A simple IP67-rated connector housing: 50mm × 30mm × 25mm block with a 16mm circular port on one face, an M25 cable gland hole 25mm on the back, and an O-ring groove around the connector port.
+39. A simple lab instrument box with rubber feet recesses: 200mm × 150mm × 80mm, 4mm walls, four hemispherical recesses 15mm diameter and 4mm deep in the base corners.
+40. A simple split-clamp electrical housing: two identical half-cylinder halves 60mm diameter and 80mm long, 4mm thick, with M4 flange bolts on each split edge.
+41. A simple cable organiser box for a desk: 150mm × 100mm × 80mm with a 80mm × 60mm opening on the back for cable exit and a 100mm × 40mm opening on the front for access.
+42. A simple project enclosure with a clear window cutout: 120mm × 80mm × 40mm, 3mm walls, a 60mm × 30mm rectangular cutout on the top face for a display window.
+43. A small outdoor sensor housing: 60mm × 50mm × 30mm with a semi-dome top, 3mm walls, four 1mm weep holes in the base, and a 6mm cable gland boss.
+44. A simple hinged inspection cover: 80mm × 60mm × 8mm lid with a 4mm hinge barrel on one long edge and a 3mm snap tab on the opposite edge.
+45. A simple recessed ceiling junction box: cylinder 100mm inner diameter and 50mm deep, 3mm wall, with a 10mm flange rim, four 4mm screw holes in the flange, and two 20mm cable knockouts.
+46. A simple handheld remote control housing: 130mm × 55mm × 25mm, 3mm walls, curved ergonomic back, four button holes 12mm diameter on the front face, and a 5mm battery compartment slot on the back.
+47. A simple 3D-printed wall switch plate: flat plate 83mm × 83mm × 8mm with a 50mm × 26mm rectangular cutout for a standard rocker switch and two M3 mounting holes.
+48. A simple electronics distribution block: 100mm × 40mm × 30mm with 3mm walls and twelve 4mm terminal wire-entry holes drilled in a 2×6 pattern on the top face.
+49. A simple 3D-printed cable duct cover: flat plate 100mm × 60mm × 3mm with a 5mm lip on three sides and clip tabs on the fourth edge.
+50. A simple motor driver enclosure: 80mm × 60mm × 30mm, 3mm walls, large ventilation slot 60mm × 5mm on top, terminal block holes on each short end.
+51. A two-part enclosure with alignment pins: 120mm × 80mm × 50mm bottom half with two 4mm alignment pins on the split face, and a lid with matching 4mm sockets.
+52. A simple stacked electronics tray (one level): 100mm × 80mm × 20mm tray with 3mm walls, open top, M3 holes on each corner wall for stacking rails.
+53. A simple bus bar housing: 200mm × 30mm × 25mm with 3mm walls and four 12mm diameter conductor holes on the top, evenly spaced.
+54. A simple in-wall recessed outlet box (exterior): rectangular 85mm × 50mm × 45mm with four 4mm corner screw holes and two 20mm knockout cable entries.
+55. A simple LED strip diffuser channel: 300mm × 12mm × 8mm U-channel with a flat diffuser cover slot 10mm wide.
+56. A simple 12V battery holder enclosure: 185mm × 80mm × 75mm outer box, 4mm walls, lid with M4 screws, and two 4mm terminal access holes.
+57. A simple signal distribution box with labelled zones: 150mm × 100mm × 60mm with partitioned interior (3mm dividing wall creating two equal chambers), separate cable entry on each chamber.
+58. A simple control panel sub-assembly housing: 200mm × 120mm × 80mm with a 60-degree angled front panel, three 22mm button holes, one 45mm meter cutout, and two 10mm cable glands.
+59. A simple weatherproof enclosure with drip cover: 100mm × 80mm × 50mm box with a 10mm-wide overhanging roof extending 15mm on all four sides to deflect rain.
+60. A simple cable pass-through grommet housing: cylinder 30mm outer diameter and 20mm tall with a 15mm bore and a 40mm diameter flange 3mm thick at the rear.
+61. A simple test equipment carrying handle housing: curved handle 150mm long, 20mm × 15mm cross-section, with two flat mounting arms 40mm × 20mm × 5mm.
+62. A simple RPi touchscreen enclosure (bottom tray only): 180mm × 110mm × 30mm tray matching the standard RPi 7" touchscreen footprint, with four M2.5 corner standoffs.
+63. A simple network switch mini enclosure: 140mm × 90mm × 30mm with five RJ45 port cutouts 18mm × 15mm on the front face and a DC barrel jack cutout on the back.
+64. A simple low-profile sensor node enclosure: 80mm × 50mm × 15mm with 2mm walls, a 5mm coin cell battery compartment, and a 10mm × 5mm sensor window.
+65. A simple component testing jig box: 100mm × 80mm × 40mm with open top and a 50mm × 40mm rectangular plinth in the centre rising 15mm for positioning a DUT.
+66. A simple 3D-printed voltmeter enclosure: 100mm × 60mm × 40mm with a 45mm × 30mm front panel cutout for the display, two 8mm banana jack holes, and a power entry hole.
+67. A simple outdoor camera housing (barrel type): cylinder 80mm outer diameter and 120mm long, 4mm walls, one end closed with a 60mm lens cutout, other end flanged for mounting.
+68. A simple two-compartment pill case: 60mm × 30mm × 20mm box divided by a central 2mm wall into two equal compartments, with a sliding 2mm-thick lid.
+69. A simple modular rack tray: 100mm × 200mm × 30mm tray with a 5mm front lip and four alignment holes on the sides for sliding into a modular rack system.
+70. A simple panel-mount socket housing: rectangular box 80mm × 50mm × 30mm with a large 50mm × 30mm cutout on the front, flanged for panel mounting with M3 screws.
+71. A simple cable management spine: 200mm × 30mm × 15mm L-shaped channel with a 20mm × 10mm U-channel on one face and clip slots every 25mm.
+72. A simple weatherproof switch housing: cylinder 50mm outer and 40mm tall with a 22mm push button hole, O-ring groove inside the bore, and two wall-mount ears.
+73. A simple 3D-printed NAS drive bay: 102mm × 152mm × 27mm (2.5" drive form factor) tray with four rubber grommet holes and a sliding locking tab.
+74. A simple fume extraction enclosure: 200mm × 200mm × 150mm box, 4mm walls, open front face, 80mm fan opening on the back face with a filter slot 82mm × 82mm × 5mm deep.
+75. A simple PCB test fixture enclosure: 150mm × 100mm × 60mm with a hinged lid, two rows of 2.54mm probe pinholes along the top face for pogo pins, and M3 alignment corner bosses.
+76. A simple 3D-printed distribution amplifier box: 120mm × 80mm × 40mm with four BNC port cutouts on each long side and a power barrel jack on one end.
+77. A simple handheld meter housing: 150mm × 70mm × 30mm, ergonomic rounded back, rubber bumper groove around the perimeter (3mm wide channel), display cutout 80mm × 40mm on the front.
+78. A simple 48V PoE splitter box: 80mm × 50mm × 30mm with RJ45 cutouts on each end and a DC barrel output on one side.
+79. A simple 3D-printed glow-in-the-dark emergency exit sign body: flat plate 200mm × 80mm × 15mm, illuminated face surface (flat), with two 5mm mounting holes. Color: the sign body in dark green.
+80. A simple desktop timer enclosure in red: 100mm × 60mm × 40mm, 3mm walls with a 40mm × 25mm display cutout and two 12mm button holes. Color: red body.
+81. A simple alarm siren enclosure in yellow: 80mm × 80mm × 50mm cylinder with a 20mm circular speaker cutout and wall-mount ear. Color: bright yellow.
+82. A simple USB charger port hub enclosure in white: 120mm × 50mm × 30mm with six USB-A port cutouts on the front face. Color: white.
+83. A simple outdoor sensor node in light grey: 60mm × 50mm × 30mm with a semi-transparent dome top placeholder and two 5mm weep holes. Color: light grey.
+84. A simple first aid box: 200mm × 150mm × 80mm, 4mm walls, hinged lid, red cross symbol embossed 80mm × 80mm on the lid face. Color: white body, red cross.
+85. A simple enclosure with colour-coded port rings: 100mm × 60mm × 40mm box, 3mm walls, USB-A port hole with a blue ring boss, audio jack hole with a green ring boss. Color: dark grey body.
+86. A simple 3D-printed sorting tray for resistors: flat tray 200mm × 100mm × 15mm divided into ten equal compartments by 2mm walls, each 18mm × 90mm. Color: black.
+87. A simple tool organiser panel: flat plate 300mm × 200mm × 8mm with 12 circular holes 20mm diameter in two rows for holding screwdrivers upright. Color: orange.
+88. A simple model rocket avionics bay: cylinder 54mm inner diameter and 100mm long, 2mm wall, with two 4mm machine screw holes on each end cap flange.
+89. A simple 3D-printed plant sensor enclosure: 40mm × 30mm × 60mm tall, 2mm walls, tapered bottom to a spike 20mm long for insertion in soil, LED hole 5mm on top.
+90. A simple cable junction conduit enclosure: 150mm × 100mm × 60mm with 20mm conduit entry stubs (24mm outer, 20mm inner, 30mm long) on three faces.
+91. A simple 3D-printed junction enclosure with two glands: 80mm × 60mm × 40mm, 3mm walls, two M20 cable gland bosses (22mm outer cylinder, 20mm bore, 20mm tall) on opposite ends.
+92. A simple industrial sensor head: cylinder 30mm outer and 25mm inner diameter, 60mm long, with a flat detection face and 4mm wire entry holes on the tail end.
+93. A simple custom keypad housing: 100mm × 80mm × 20mm, 3mm walls, a 3×4 grid of 12mm button holes on the top face, and a 5mm cable exit on the back.
+94. A simple alarm control panel housing: 200mm × 150mm × 60mm with a 150mm × 100mm front face cutout for a panel, four M4 mounting holes, and a cable tray channel on the back.
+95. A simple camera trap housing: 120mm × 80mm × 60mm, 4mm walls, 30mm lens cutout on the front, PIR sensor cutout 24mm on the top face, and 4 wall-mount keyhole slots.
+96. A simple 3D-printed mini server rack unit: 430mm × 200mm × 45mm (1U form factor) with 4mm walls, two mounting ear cutouts on each side, and a 140mm fan opening on the back.
+97. A simple audio effects pedal enclosure: 120mm × 65mm × 40mm, 4mm walls, front face with three 10mm knob holes and one 6mm jack socket hole, back face with two 6mm jack socket holes.
+98. A simple flow sensor housing: cylinder 40mm outer and 20mm inner bore, 80mm long, with two port bosses 15mm diameter on the sides (in-flow and out-flow ports).
+99. A simple custom LoRa gateway enclosure: 120mm × 80mm × 40mm, 3mm walls, SMA antenna hole 7mm on top, RJ45 hole on one end, DC barrel power hole on the same end, and a ventilation slot.
+100. A simple 3D-printed case for an M5Stack module: 55mm × 55mm × 24mm, 2mm walls, open on the front face for the screen, USB-C hole on the bottom, and four M3 corner through-holes.

--- a/workbench/categories/11-pcb-cases.md
+++ b/workbench/categories/11-pcb-cases.md
@@ -1,0 +1,212 @@
+---
+rank: 11
+name: PCB Cases
+complexity: 10
+description: >
+  Board-specific enclosures for common single-board computers and microcontroller
+  development boards. Requires accurate port cutout placement, PCB standoff positions,
+  and structural features matching real hardware dimensions. The highest complexity
+  category, demanding precise dimensional knowledge of real hardware.
+---
+
+## Examples
+
+1. A two-part enclosure for a Raspberry Pi 4 Model B. The base holds the PCB on four 2.9mm brass-insert standoffs at standard hole positions, with cutouts on the long side for USB-A ports, USB-C power, and HDMI micro connectors. The lid snaps on and has a circular exhaust vent grid centered above the SoC.
+
+2. A slim Raspberry Pi 4 case with a passive cooling fin tower integrated into the lid. The fins run parallel to the board's long axis, each 2mm thick and 8mm tall. The base has the standard port cutouts; the lid has no vents — heat transfers through the fins.
+
+3. A Raspberry Pi 4 DIN-rail mounting case. The back wall has two standard 35mm DIN-rail clips. The PCB sits on standoffs inside; port cutouts face the front. Total depth from the rail to the front face is 45mm.
+
+4. A tall stack enclosure for a Raspberry Pi 4 plus a 3.5-inch touchscreen HAT. The base accepts the Pi on standoffs; the HAT sits on a second standoff tier 15mm above. The front face has a 76mm × 47mm rectangular opening for the screen, flush with the HAT's display bezel.
+
+5. A Raspberry Pi 5 enclosure with an active cooler bay. The lid has a 50mm × 50mm square opening centered over the SoC for the official active cooler to protrude 6mm. The base has the Pi 5's four-hole standoff pattern; port cutouts match the USB 3.0 and USB-C positions unique to the Pi 5.
+
+6. A Raspberry Pi 5 case with an NVMe SSD tray. The base is 20mm taller than the PCB to accommodate an M.2 2242 SSD mounted below the board on a secondary bracket shelf. A cutout on the rear wall exposes the PCIe connector ribbon cable.
+
+7. A Raspberry Pi Zero 2 W case — 70mm × 32mm footprint. The base holds the board on four 2mm standoffs. Cutouts on one short edge for micro-USB power and data; one long edge for the mini-HDMI port; the opposite long edge for the camera ribbon slot. The lid is plain and flat.
+
+8. A Raspberry Pi Zero 2 W wearable band mount. The case is 72mm × 35mm × 16mm, with two 25mm-wide strap loops integrated into the short ends. Cutouts match the Zero 2 W ports. The lid clips on and is 2mm thick.
+
+9. A Raspberry Pi Zero W case with GPIO header access. The lid has a 51mm × 5mm slot along the long axis to expose the 40-pin header. All port cutouts on the short edges are present. Walls are 2mm thick.
+
+10. A Raspberry Pi 3 Model B+ case with camera mount arm. A 15mm-wide articulating arm is hinged to one corner of the lid. The arm end holds a 25mm × 24mm platform with a central slot for the Pi Camera ribbon cable and a small bracket to hold the camera module flat.
+
+11. A Raspberry Pi 3 Model B media-center case with ventilation. The case resembles a miniature set-top box: 100mm × 75mm × 30mm, with a fine hex grid on the top covering 60% of the surface area. Port cutouts on all four sides match the Pi 3 layout.
+
+12. A Raspberry Pi Compute Module 4 IO board enclosure. The board is 160mm × 90mm. The case has standoffs at the four IO board mounting holes, side cutouts for USB 3.0, 2× HDMI, Ethernet, and the PCIe slot. The lid is removable and vented.
+
+13. An Arduino Uno R3 enclosure. The base holds the board on four standoffs at the R3 hole pattern, with a 68mm × 53mm PCB footprint. Cutouts on the short edge for the USB-B port and barrel jack; the long edge is open to expose the pin headers. The lid has no holes.
+
+14. An Arduino Uno R3 project box with protoshield bay. The base accommodates the Uno; the lid is 20mm taller than standard, creating a 68mm × 53mm × 15mm cavity above the board for a protoshield with header clearance. The front face is blank.
+
+15. An Arduino Uno R3 wall-mount enclosure with label window. A 50mm × 15mm rectangular recess on the lid top accepts a paper label under a clear 1mm-thick polycarbonate-style inlay plate. Two keyhole slots on the back wall for M4 screws.
+
+16. An Arduino Mega 2560 R3 case. The board footprint is 101.6mm × 53.3mm. The base has standoffs at the four corner holes; cutouts on the short edge for the USB-B and barrel jack; the long edge is fully open (no wall) to expose the large pin header banks. Walls are 2.5mm thick.
+
+17. An Arduino Mega 2560 case with LCD bay. The front panel has a 71mm × 39mm opening with a 1mm ledge for a 16×2 LCD module. Six push-button cutouts (10mm diameter each) are arranged in two rows of three below the LCD opening.
+
+18. An Arduino Nano mounting cradle. The cradle is a simple U-channel 50mm × 20mm × 12mm that the Nano drops into. Spring-tab clips on the two short ends hold the board. Micro-USB cutout on one short end; the other end is open for the digital pin headers.
+
+19. An Arduino Nano Every case. Matches the Nano footprint (45mm × 18mm) with 3mm standoffs. Cutouts for micro-USB on one short end. The lid is slim (1.5mm) with a 40mm × 14mm window to expose the board silkscreen label.
+
+20. An Arduino Nano 33 IoT case with antenna clearance notch. The antenna is positioned at one corner; the case has a 5mm × 5mm notch at that corner to avoid blocking the 2.4 GHz antenna. Standard USB cutout on the opposite short end.
+
+21. An Arduino Pro Mini breakout case. The board is 33mm × 18mm. The case holds it on 2mm standoffs; cutouts on the short edge for the serial header pins. The lid is plain, attached by two M2 screws.
+
+22. An Arduino Leonardo enclosure. Footprint similar to the Uno; main difference is the micro-USB port position. The case has a micro-USB cutout centered on the short edge and a barrel-jack cutout offset 13mm from the corner. Standoffs at standard Uno hole positions.
+
+23. An ESP32 DevKit V1 case. The board is 52mm × 28mm. The case holds it on 2mm standoffs; cutouts on both short ends for the micro-USB port and the EN/BOOT buttons. The lid has a small window over the onboard LED position.
+
+24. An ESP32 DevKit V1 outdoor weather station housing. The case is 80mm × 50mm × 35mm with four M4 mounting holes on the back for outdoor wall mounting. Ventilation slots on the bottom edge for passive airflow without direct rain exposure. Micro-USB cutout sealed with a rubber-plug boss on the short side.
+
+25. An ESP32 WROOM-32 module bare PCB case. The module is 38mm × 25.5mm. The case is minimal: a 40mm × 27mm base with 1.5mm walls and a snap-lid. Antenna clearance notch on one short end for the SMD antenna.
+
+26. An ESP32-S3 DevKitC-1 enclosure. Board is 65mm × 26mm with USB-C on one short end. Two large DFN cutouts on each long side expose all GPIO pin headers for prototyping. Lid is a simple 1.5mm flat cap.
+
+27. An ESP32-CAM enclosure with lens port. The board is 40mm × 27mm with the OV2640 camera module protruding 3mm from the front. The case has a 14mm circular opening on the front face for the lens, surrounded by a 1mm standoff ring. Micro-USB cutout on the opposite end.
+
+28. A NodeMCU ESP8266 (v3 Lolin) case. Board footprint is 58mm × 31mm. Cutouts on one short end for the micro-USB port. Both long sides are open between the top and bottom rails to expose all pin headers. The lid clips on flush.
+
+29. A NodeMCU v2 (Amica) enclosure with breadboard window. The lid has a 55mm × 28mm open slot exposing the top of the board, intended for use with a half-size breadboard attached via adhesive above. Short-end USB cutout present.
+
+30. A Wemos D1 Mini case. The board is 34mm × 25mm. The case has 2mm standoffs at the four corners; micro-USB cutout on the short end. The lid is flat with a small LED window aligned to the onboard LED.
+
+31. A Wemos D1 Mini Pro case with external antenna cutout. A 3mm × 8mm slot on one long edge provides clearance for the U.FL antenna connector and a 50mm external whip antenna.
+
+32. A Wemos S2 Mini enclosure with USB-C cutout. The board is 34mm × 27mm. Two short-end cutouts for USB-C and the RESET button. Standoffs at the four mounting holes. Slim 1.5mm walls and lid.
+
+33. An ESP8266 bare module (ESP-12E) enclosure. The module is 24mm × 16mm. The case holds it in a recessed pocket with an antenna clearance notch on one short end. 2mm walls; no pin header cutouts — intended for firmware-flashed sealed use.
+
+34. A Seeed XIAO ESP32-C3 case. The board is 21mm × 17.5mm, one of the smallest. The case is 24mm × 20mm × 10mm; USB-C cutout on one short end. Tiny snap lid. Antenna notch on the USB-C end.
+
+35. A Seeed XIAO RP2040 enclosure. Same 21mm × 17.5mm footprint as other XIAO modules. USB-C cutout and two edge pads exposed via 1mm slots on each long edge. Snap lid.
+
+36. A Raspberry Pi Pico W case. The board is 51mm × 21mm. The case holds it on 2mm standoffs; micro-USB cutout centered on one short end. LED window over the onboard LED. Antenna notch on the opposite short end. Snap lid.
+
+37. A Raspberry Pi Pico H case with debug port access. The three-pin SWD debug port is exposed through a 10mm × 5mm slot on the long edge. Micro-USB cutout on the short end. 2.5mm walls with corner snap clips.
+
+38. A Teensy 4.1 enclosure. The board is 61mm × 18mm. Cutouts on one short end for the micro-USB port; the other short end has an SD card slot cutout (matching the 32mm × 2.5mm slot). Long edges are open for pin header access.
+
+39. A Teensy 4.0 minimal case. Board is 35.5mm × 17.8mm. Micro-USB cutout on the short end. Long-side pin rails exposed through open channels. Flat snap lid.
+
+40. A STM32 Nucleo-64 enclosure. The board is 70mm × 53mm with the Arduino-compatible connectors on the long edges. The case leaves both long edges open for pin header access. Short-edge cutouts for the CN1 USB mini-B port and the reset button. A 10mm × 6mm window on the lid exposes the user LED and button.
+
+41. A STM32 Nucleo-32 case. Smaller board: 63mm × 33mm. Long edges open for pin access; short-edge USB mini-B cutout. Lid has an LED window.
+
+42. A STM32 Nucleo-144 enclosure. Large board: 143mm × 107mm. The case has standoffs at all six mounting holes. Long edges open for pin header access. Short edges have cutouts for the USB port, Ethernet, and user buttons. Lid has a hex vent grid.
+
+43. A Blue Pill STM32F103 case. The board is 53mm × 23mm. Micro-USB cutout on one short end. BOOT jumper access slot on the opposite short end (3mm × 5mm). Long edges are open for pin header access. Flat snap lid.
+
+44. A Black Pill STM32F411 enclosure. Board is 52mm × 21mm. USB-C cutout on one short end. Lid is 1.5mm flat with a central 20mm × 8mm slot exposing the SoC top.
+
+45. An Arduino Due enclosure. The board is 101.6mm × 53.3mm (same as Mega). Cutouts for two USB micro connectors on the short edge (programming and native USB, 12mm apart). Long side fully open for shield pin access. Lid is plain.
+
+46. A BeagleBone Black case. The board is 86.4mm × 54.6mm. Standoffs at four mounting holes; cutouts on the short ends for mini-USB (P4), USB-A host, Ethernet, and the microSD slot. 2mm HDMI cutout on one long side.
+
+47. A NVIDIA Jetson Nano developer kit enclosure (B01). The carrier board is 100mm × 80mm. Standoffs at four corners; front-face cutouts for USB-A (×4), USB micro, HDMI, and Ethernet. Rear cutout for the DC barrel jack. The lid has a 40mm × 40mm square opening above the heatsink/fan area.
+
+48. A Jetson Nano 2GB case. Board footprint 100mm × 80mm; single USB-C power port replaces the DC barrel. Lid has fan opening 40mm × 40mm. SD card slot cutout on the long side.
+
+49. A Google Coral Dev Board case. Board is 88mm × 60mm. Cutouts for USB-C, USB micro, HDMI micro, Ethernet, and the 40-pin GPIO header on the long edge. Lid has a 40mm × 40mm fan vent.
+
+50. A Raspberry Pi 4 PoE HAT enclosure. The case is 10mm taller than a standard Pi 4 case to accommodate the PoE HAT stacked on top. The Ethernet port cutout is elongated to 20mm height to allow the PoE connector. Fan exhaust vent on the lid.
+
+51. A custom 100mm × 80mm PCB project case. The base has four standoffs in a 80mm × 60mm rectangle (M3, 5mm height). The front panel has four circular cutouts (8mm diameter) for LEDs, two rectangular cutouts (7mm × 4mm) for slide switches, and a USB-B cutout at the bottom edge. Lid plain.
+
+52. A custom 60mm × 40mm sensor node PCB case. Small box, 65mm × 45mm × 20mm. Single M3 standoff at each corner. A 10mm diameter circular hole on the top face for a sensor probe. Micro-USB cutout on the short end. Lid hinged on one long side.
+
+53. A custom 120mm × 80mm power supply PCB case. Robust walls (3mm thick). The front panel has a 20mm × 12mm rectangular cutout for a DC barrel jack and a 16mm circular cutout for a power switch. The rear panel has a 20mm × 10mm IEC C14 inlet rectangle cutout. Internal standoffs at six positions in a 100mm × 60mm arrangement.
+
+54. A LoRa32 TTGO V2.1 case. The board is 50mm × 25.5mm with a 0.96-inch OLED and SMA antenna connector. The front face has a 25mm × 13mm window for the OLED display. A 6mm circular hole on the top for the SMA connector. USB-C cutout on the bottom short end.
+
+55. A TTGO T-Display ESP32 enclosure. The board is 51mm × 25mm with a 1.14-inch IPS screen. The front face has a 26mm × 14mm display window. Two button cutouts (4mm diameter) on the short bottom edge. USB-C cutout on the short top edge.
+
+56. A M5Stack Core ESP32 case. The unit is 54mm × 54mm × 17mm with a 2-inch display, three face buttons, and USB-C on the bottom. The outer shell has a 44mm × 35mm display bezel window on the front, three 8mm × 4mm button slots on the front bottom, and a USB-C cutout on the bottom edge. Color: mid-grey body with black bezel.
+
+57. A M5Stack ATOM Lite case. The module is 24mm × 24mm × 10mm. The case is a 26mm × 26mm × 12mm box with a 5mm circular window on the front face for the RGB LED. USB-C cutout on the bottom. Corner snap clips.
+
+58. A Feather M0 WiFi case (Adafruit). The board is 51mm × 23mm. USB micro cutout on one short end; LiPo JST connector on the opposite short end (3mm × 5mm slot). Long edges open for pin header access. Flat snap lid.
+
+59. An Adafruit Feather RP2040 case. Board is 51mm × 23mm; USB-C replaces micro-USB. Same geometry as Feather M0 otherwise. Lid has a small reset button access hole (3mm diameter).
+
+60. A Feather Wing stacked case for Feather + Doubler. The base is 60mm × 45mm to accommodate the Doubler board footprint. 12mm spacers raise the second Feather tier. The combined case height is 35mm. USB cutout on the front short edge.
+
+61. An Adafruit Circuit Playground Express case. The board is circular, 50mm diameter. The case is cylindrical, 56mm inner diameter, 10mm tall, with the flat top having ten 4mm LED windows arranged in a circle and a USB micro cutout on the side wall.
+
+62. An Adafruit Metro M4 Express case. Board is 68.6mm × 53.3mm (Arduino Uno footprint compatible). USB micro cutout plus barrel jack on short edge. Lid has hex ventilation pattern.
+
+63. A Banana Pi M5 case. Board is 92mm × 60mm. Similar layout to Raspberry Pi with USB, HDMI, and Ethernet on the short edge. Lid has 40mm × 40mm vent opening above the SoC area.
+
+64. An Orange Pi Zero 3 enclosure. Board is 67mm × 67mm. Cutouts for USB-A, USB-C, HDMI micro, Ethernet, and GPIO header on four sides. Lid has small hex vent grid over the SoC.
+
+65. A Rock Pi 4 case. Board is 85mm × 54mm. USB-A, USB-C, HDMI, Ethernet cutouts on the short edges. GPIO header cutout on one long edge. Heatsink vent on the lid.
+
+66. A Pine A64 enclosure. Board is 133mm × 80mm. Cutouts for 2× USB-A, Ethernet, HDMI, and DC barrel on short edges. GPIO header accessible via long-edge opening. Plain vented lid.
+
+67. An Odroid-C4 case. Board is 90mm × 57mm. Cutouts for 4× USB 3.0, Ethernet, HDMI 2.0, and DC barrel on the short side. Top vent grid over the SoC heatsink position.
+
+68. A NanoPi NEO3 case. Board is 40mm × 40mm square. Cutouts for USB-C, Gigabit Ethernet, and micro-SD on three sides. Top has 20mm × 20mm vent grid. Snap lid.
+
+69. A Banana Pi M2 Zero case. Board is 65mm × 30mm (Pi Zero form factor). Cutouts for mini-HDMI, USB micro OTG, and USB micro power on the short edges. CSI ribbon slot on the long edge. Flat snap lid.
+
+70. A custom relay board enclosure (4-relay module, 80mm × 58mm PCB). The case is 90mm × 68mm × 35mm. The front panel has four 12mm × 10mm rectangular windows for the relay indicator LEDs. Screw terminal access slots (6mm × 3mm each) on the rear panel. DIN-rail mount clips on the bottom.
+
+71. A Raspberry Pi 4 touchscreen kiosk housing. A 100mm-wide wall-mount frame holds a 7-inch DSI display (155mm × 95mm screen area) and a Pi 4 in a single unit. The front bezel is 165mm × 110mm with a 150mm × 90mm display cutout. Four M4 keyhole slots on the back for wall mounting.
+
+72. An Arduino Uno + Ethernet Shield case. Two-tier case; the bottom tier holds the Uno; the upper tier (15mm taller) holds the Ethernet shield. The short edge has the USB-B cutout and an Ethernet RJ-45 cutout (16mm × 14mm). Both headers bridged internally.
+
+73. A Raspberry Pi Zero 2 W hidden-in-plug style case. Mimics a wall charger: 65mm × 45mm × 28mm with two rectangular plug prong slots on the back face (14mm × 4mm, 19mm apart). No actual functionality. Micro-USB cutout on one edge for power-only use. Minimalist enclosure.
+
+74. An ESP32 smart home controller case with display and buttons. 90mm × 60mm × 30mm. Front face: 60mm × 35mm display window, four 8mm circular button cutouts in a row below the display, a 10mm × 5mm status LED strip window. Back: two M3 keyhole wall-mount slots.
+
+75. A LoRaWAN gateway module case for a RAK831 / RAK7271 module (99mm × 71mm). Aluminum-style ribs (3mm-wide raised fins, 1mm apart) on the top lid for heat dissipation aesthetics. Front panel: two SMA antenna connectors (6.5mm holes, 20mm apart), USB micro cutout. DIN-rail clips on the back.
+
+76. A Raspberry Pi 5 cluster node tray for four units. Each node bay is 90mm × 65mm; four bays in a 2×2 grid separated by 5mm walls. Each bay has individual port cutouts. The tray bottom has ventilation slots between bays. Total tray: 195mm × 145mm × 50mm.
+
+77. A custom 40-pin GPIO breakout tray for a Raspberry Pi 4. The Pi sits recessed 5mm into the base. The lid has a full 51mm × 5mm slot exposing the 40-pin header. All other port cutouts present. The lid is screwed on via four M2.5 bolts.
+
+78. A Seeed reTerminal enclosure mock-up (standalone front bezel). 170mm × 100mm front frame with a 148mm × 84mm window for the 5-inch touchscreen, two 8mm button cutouts on the right side, and a USB-A cutout on the top edge. 3mm wall thickness.
+
+79. A transparent-body Raspberry Pi 4 case with a royal blue lid and base trim. The four side walls would be rendered as transparent; the lid and bottom plate as royal blue (RGB 0, 55, 180). PCB standoffs at standard Pi 4 hole positions; standard port cutouts on all sides. Color: transparent walls, blue lid and base.
+
+80. A red-and-black Arduino Uno project enclosure. The main body is matte black; the lid is bright red. USB-B and barrel jack cutouts on the short end. Two red circular bosses on the lid for status LEDs. Color: black body, red lid.
+
+81. A green PCB-tray insert for an ESP32 DevKit in a standard 80mm × 40mm DIN-rail housing. The tray is leaf-green (RGB 60, 160, 60) and holds the ESP32 on 2mm standoffs. Designed to slide into a separately printed housing. Color: leaf green.
+
+82. An orange Raspberry Pi Zero W case for field identification. All parts (base and lid) printed in safety orange (RGB 255, 100, 0). Standard Zero W port cutouts. Micro-USB and mini-HDMI on the short edges. Color: safety orange throughout.
+
+83. A two-tone Jetson Nano case: charcoal grey base with a silver-grey lid. The lid has a 40mm × 40mm square fan opening. Standoffs at the B01 four-hole pattern. Cutouts for USB-A, USB micro, Ethernet, HDMI. Color: charcoal grey base (RGB 55, 55, 55), silver lid (RGB 180, 180, 180).
+
+84. A Raspberry Pi 5 enclosure with color-coded port trim rings. The main body is white. Around each port cutout, a 2mm raised ring is colored: USB-A cutouts get blue rings, the USB-C gets red, HDMI cutouts get black. Color: white body, blue USB-A rings, red USB-C ring, black HDMI rings.
+
+85. A deep-purple BeagleBone Black enclosure for maker events. Deep purple (RGB 90, 0, 120) body and lid. Standard BeagleBone Black port cutouts. Four M3 standoffs at the four mounting holes. Color: deep purple throughout.
+
+86. A Raspberry Pi cluster node in branded yellow-black. The case body is matte yellow (RGB 240, 200, 0) with black lettering indentations ("NODE-01") embossed 0.5mm into the lid top. Port cutouts standard for Pi 4. Lid snaps on. Color: yellow body, black embossed text.
+
+87. A Seeed XIAO ESP32-S3 Sense camera case in translucent blue. 24mm × 22mm × 14mm; the front face has a 4mm circular lens opening for the onboard camera module. USB-C cutout on the short end. Color: translucent light blue (RGB 180, 220, 255).
+
+88. A wall-mount enclosure for a Raspberry Pi 3 B+ home automation controller. 110mm × 80mm × 30mm; rear has four M4 keyhole screw slots in a 90mm × 60mm pattern. Front panel has a 60mm × 35mm display window and two 8mm push-button holes. Standard Pi 3 B+ port cutouts on the sides.
+
+89. A desk stand enclosure for an ESP32 WROOM with a tilt angle of 25 degrees. The base is 80mm × 50mm at ground level; the case tilts backward at 25 degrees, putting the ESP32 display (if any) at a comfortable reading angle. Anti-slip pads embossed on the bottom corners.
+
+90. An IP54-rated splash-resistant ESP32 outdoor enclosure. 80mm × 60mm × 40mm. All walls are 3mm thick. Lid-to-body joint has a 1.5mm × 1.5mm O-ring groove. Four M3 screws secure the lid. Cable gland hole (11mm diameter) on the base for a PG7-size gland. Micro-USB cutout behind a hinged rubber flap boss.
+
+91. A 3D-printable mounting bracket that clips a NodeMCU ESP8266 to a standard electrical junction box (DIN 60mm). The bracket is 65mm × 35mm with a U-channel for the NodeMCU and two spring clips to snap onto the junction box rim. Micro-USB faces outward.
+
+92. An Arduino Nano Every with integrated 128×64 OLED display case. The OLED (27mm × 27mm module) is mounted on the lid above the Nano. The lid has a 26mm × 13mm display window. The Nano sits on standoffs in the base. A 5V power rail and I2C SDA/SCL bridge are implied by the internal routing space.
+
+93. A Raspberry Pi Pico W weather station enclosure with sensor ports. 65mm × 35mm × 25mm body. Three 8mm sensor probe holes on the top face. Micro-USB cutout on the short end. Snap lid. Base has a flat mounting flange with two M3 holes for surface mounting.
+
+94. A Raspberry Pi 4 compute blade sled for a 3U rack enclosure. The sled is 133mm wide × 480mm deep (half 19-inch rack depth). The Pi mounts sideways; two USB-A cutouts face the front panel; HDMI and Ethernet face the rear. The sled slides on 1mm-wide guide rails and is ejected by a push-tab on the front face.
+
+95. An ESP32 pendant enclosure with neck-loop attachment. 50mm × 30mm × 12mm oval body, smooth edges, chamfered corners. A 6mm × 4mm slot on the top short end accepts a neck cord. Micro-USB on the bottom. The front face is smooth (for a small e-ink display, implied). Color: pearl white.
+
+96. A Raspberry Pi Zero 2 W magnetic refrigerator magnet case. The base is 75mm × 38mm × 6mm; a 20mm × 5mm × 3mm recess on the back accommodates a standard fridge magnet insert. Port cutouts on the short edges. Snap lid is 1mm thick.
+
+97. A Jetson Nano Orin NX 8GB industrial mount case. 110mm × 80mm × 50mm. The board is 103mm × 80mm; standoffs at four corners. Front panel: USB-A, USB-C, HDMI, Ethernet cutouts. Top: 40mm × 40mm fan opening with 4× M3 fan mount holes. DIN-rail clips on the rear.
+
+98. A Raspberry Pi 5 AI HAT+ add-on case. The base accepts the Pi 5 on standard standoffs. The AI HAT adds 18mm height; four additional standoffs in the same hole pattern support the HAT. The lid sits above both boards. Total internal height: 40mm. Large vent grid (70mm × 50mm) on the lid for the 13 TOPS NPU heat dissipation.
+
+99. A custom four-layer PCB stack enclosure for an Arduino Mega + motor shield + sensor shield + Bluetooth module. Each layer adds 15mm. Total case height: 75mm. The base holds the Mega on standoffs; each shield layer has an additional 5mm standoff tier. The front face has a 20mm × 8mm rectangular slot per layer for status LEDs. USB-B cutout on the short edge of the base tier.
+
+100. A universal open-frame PCB cage for boards up to 100mm × 80mm. Consists of four corner pillars (50mm tall, M3 threaded boss on each end), two long cross-rails (100mm, M3 bolt slots every 10mm), and two short cross-rails (80mm, same). No walls or lid — fully open skeleton that accepts any board with M3 mounting holes in a 90mm × 70mm footprint. Designed for maximum airflow.


### PR DESCRIPTION
## Summary

This PR introduces the design document and initial curriculum structure for the Build123d LLM Workbench — an admin-only feature for generating and curating a high-quality dataset of Build123d Python code examples for fine-tuning an open-weight LLM.

## Changes

- **Design Document** (`docs/build123d-llm-workbench.md`): Comprehensive 815-line specification covering:
  - System overview, goals, and problem statement
  - Key architectural decisions (integrated into Chat3D, separate STL rendering service, VLM-based auto-evaluation)
  - Complete database schema for categories, example prompts, generated examples, and system prompts
  - Automated generation pipeline with fix-iteration loop (max 5 iterations)
  - Visual evaluation (VLM) approach with reference image search integration
  - Target fine-tuning model (Qwen3-Coder-Next) and training dataset format
  - Environment variables and Docker service configuration

- **Curriculum Structure** (11 category files in `workbench/categories/`):
  - `01-primitives.md` through `11-pcb-cases.md`
  - Each category contains 100 user-facing example prompts (natural language descriptions, no code hints)
  - Complexity levels range from 1 (basic primitives) to 10 (PCB-specific enclosures)
  - Frontmatter metadata (rank, name, complexity, description) for seeding into database
  - Total of ~1,100 example prompts across all categories

## Notable Implementation Details

- **Complexity Curriculum**: Examples progress from simple primitives (Box, Cylinder, Sphere) through sketch operations, extrusions, booleans, surface modifications, arrays, everyday objects, mechanical components, electronics, and finally PCB-specific enclosures
- **VLM Auto-Evaluation**: Visual language model scores rendered 3D models 1–10; score ≥7 triggers auto-approval; lower scores trigger fix loop with VLM suggestions
- **Fix Loop**: Combines render errors and VLM visual feedback to guide code correction across up to 5 iterations before human review
- **Reference Images**: Web image search (Bing/Google) provides real-world reference images to VLM for grounding abstract shape validation
- **Color Support**: ~5% of prompts (55/1,100) include color expectations, distributed in higher complexity categories; colored examples export 3MF instead of STL
- **Few-Shot Context**: Always retrieves complete code examples (max 6) rather than chunks to preserve import statements and context managers
- **Scale Path**: v1 targets 1,000 validated examples from ~1,100 prompts; expansion to 10,000 via re-running with varied temperature/seeds (9–10 passes per prompt)

https://claude.ai/code/session_011NMbF7y5cKdmUW6UfHCLT6